### PR TITLE
Add popup, update for current Patreon URLs, Greedy/Selective collection mode, event-driven download engine

### DIFF
--- a/js/background-main.js
+++ b/js/background-main.js
@@ -9,7 +9,9 @@ var dbVersion = 3;
 /* options */
 var downloadAttachments = true; // attachments currently only download with a "Save As" dialog; If false, these files will be ignored.
 var useLostAndFound = true; // attachments with file_name = null will be downloaded with a random generated file name to {ArtistName}_{LostAndFoundSuffix}
-var collectionMode = "greedy"; // "greedy" | "selective"
+// "greedy": collect from all creators by default, individual creators can be disabled
+// "selective": only collect from creators explicitly enabled via the popup
+var collectionMode = "greedy";
 var knownCreators = {};
 
 browser.storage.local.get('settings').then((result) => {
@@ -26,6 +28,7 @@ browser.storage.local.get('settings').then((result) => {
 		if (result.settings.hasOwnProperty('collectionMode'))
 			collectionMode = result.settings.collectionMode;
 		else if (result.settings.hasOwnProperty('contentCollectionEnabled'))
+			// migrate legacy boolean setting saved before collectionMode was introduced
 			collectionMode = result.settings.contentCollectionEnabled ? "greedy" : "selective";
 
 		if (result.settings.hasOwnProperty('knownCreators'))

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -9,9 +9,7 @@ var dbVersion = 3;
 /* options */
 var downloadAttachments = true; // attachments currently only download with a "Save As" dialog; If false, these files will be ignored.
 var useLostAndFound = true; // attachments with file_name = null will be downloaded with a random generated file name to {ArtistName}_{LostAndFoundSuffix}
-var downloadInterval = 3000; // ms
-var downloadIntervalId = 0;
-var contentCollectionEnabled = true;
+var collectionMode = "greedy"; // "greedy" | "selective"
 var knownCreators = {};
 
 browser.storage.local.get('settings').then((result) => {
@@ -25,21 +23,21 @@ browser.storage.local.get('settings').then((result) => {
 		if (result.settings.hasOwnProperty('debug'))
 			debug = result.settings.debug;
 	
-		if (result.settings.hasOwnProperty('downloadInterval'))
-			downloadInterval = result.settings.downloadInterval;
-
-		if (result.settings.hasOwnProperty('contentCollectionEnabled'))
-			contentCollectionEnabled = result.settings.contentCollectionEnabled;
+		if (result.settings.hasOwnProperty('collectionMode'))
+			collectionMode = result.settings.collectionMode;
+		else if (result.settings.hasOwnProperty('contentCollectionEnabled'))
+			collectionMode = result.settings.contentCollectionEnabled ? "greedy" : "selective";
 
 		if (result.settings.hasOwnProperty('knownCreators'))
 			knownCreators = result.settings.knownCreators;
+
+		if (result.settings.hasOwnProperty('concurrentDownloads'))
+			concurrentDownloads = result.settings.concurrentDownloads;
 	}
 
 	console.info("loaded user settings from localStorage:", result);
 
 	updateSettingsStorage();
-
-	initializeDownloadInterval();
 });
 
 function updateSettingsStorage() {
@@ -47,9 +45,9 @@ function updateSettingsStorage() {
 		downloadAttachments: downloadAttachments,
 		useLostAndFound: useLostAndFound,
 		debug: debug,
-		downloadInterval: downloadInterval,
-		contentCollectionEnabled: contentCollectionEnabled,
-		knownCreators: knownCreators
+		collectionMode: collectionMode,
+		knownCreators: knownCreators,
+		concurrentDownloads: concurrentDownloads
 	}
 
 	console.info('user settings changed:', settings);

--- a/js/content/url.js
+++ b/js/content/url.js
@@ -1,10 +1,30 @@
-const postsUrlRegex = /patreon\.com\/(\w+)\/posts/;
+// matches patreon.com/cw/{creator} and patreon.com/c/{creator}
+const creatorUrlRegex = /patreon\.com\/(?:cw|c)\/(\w+)/;
 
-let match;
+function detectAndSendCreator() {
+	let match = creatorUrlRegex.exec(window.location.href);
+	let creator = match !== null ? match[1] : null;
+	browser.runtime.sendMessage({
+		action: "setPageCreator",
+		data: { creator }
+	});
+}
 
-browser.runtime.sendMessage({
-	action: "setPageCreator",
-	data: {
-		creator: (match = postsUrlRegex.exec(window.location.href)) !== null ? match[1] : null
+detectAndSendCreator();
+
+// re-detect on SPA navigation (Patreon uses client-side routing)
+let lastUrl = window.location.href;
+new MutationObserver(() => {
+	if (window.location.href !== lastUrl) {
+		lastUrl = window.location.href;
+		detectAndSendCreator();
 	}
-});	
+}).observe(document, { subtree: true, childList: true });
+
+// popup can ask for current creator directly
+browser.runtime.onMessage.addListener(request => {
+	if (request.action === "getCreator") {
+		let match = creatorUrlRegex.exec(window.location.href);
+		return Promise.resolve({ creator: match ? match[1] : null });
+	}
+});

--- a/js/creators.js
+++ b/js/creators.js
@@ -9,7 +9,7 @@ function registerCreator(name) {
 		return;
 	}
 	
-	knownCreators[name] = contentCollectionEnabled;
+	knownCreators[name] = (collectionMode === "greedy");
 
 	updateSettingsStorage();
 }

--- a/js/creators.js
+++ b/js/creators.js
@@ -9,6 +9,7 @@ function registerCreator(name) {
 		return;
 	}
 	
+	// greedy: new creators are enabled by default; selective: require explicit opt-in
 	knownCreators[name] = (collectionMode === "greedy");
 
 	updateSettingsStorage();

--- a/js/download.js
+++ b/js/download.js
@@ -1,16 +1,17 @@
-/*	
+/*
  *	Patreon Helper for Firefox
  * 	draconigen@gmail.com
  */
 
 var db;
+var activeDownloads = 0;
+var downloadIdToDbId = new Map(); // maps Firefox download ID → our DB record ID
 
 var dbOpen = indexedDB.open("patreonex", dbVersion);
 
 dbOpen.onupgradeneeded = () => {
     console.info(`initializing downloads structure, version "${dbVersion}".`);
 
-    // version 3 - added new index (identifier), hence the old object store must be dropped
     try {dbOpen.result.deleteObjectStore("downloads")}
     catch {console.warn("could not delete downloads object store - probably none present")}
 
@@ -23,87 +24,100 @@ dbOpen.onupgradeneeded = () => {
 
 dbOpen.onsuccess = () => {
     db = dbOpen.result;
-}
 
-// background download worker, started after user settings have been loaded in background-main.js or changed in options.js
-function initializeDownloadInterval() {
-    if (downloadIntervalId !== 0) {
-        console.info(`[download worker] attempting to cancel downloadInterval with intervalID "${downloadIntervalId}"`);
-        clearInterval(downloadIntervalId);
-    }
-
-    downloadIntervalId = setInterval(() => {
-        let request = db.transaction("downloads", "readwrite").objectStore("downloads").index("state").openCursor(IDBKeyRange.upperBound(0)); // get all with state <= 0
-
-        let i = 0;
-        request.onsuccess = (event) => {
-            let downloaded = false;
-
-            if (i++ >= concurrentDownloads || !event.target.result)
-                return;
-
-            let cursor = event.target.result;
-            let filename = cursor.value.filename;
-            let url = cursor.value.url;
-
-            console.info(`downloading; filename: '${filename}', url: '${url}'`)
-
-            // served from patreonusercontent.com - download directly
-            if (url.includes('patreonusercontent.com')) {
-                let dl = browser.downloads.download({
-                    filename: filename,
-                    url: url,
-                    saveAs: false
-                })
-                .then(
-                    () => { // onsuccess
-                        // todo: [2-1]
-                    },
-                    () => { // onerror
-                        console.error(`download failed; filename: '${filename}', url: '${url}'; browser.downloads.download() returned:`, dl)
-                    }
-                );
-
-                downloaded = true;
-            }
-            // something else (e.g. http-302) - open in tab // todo: [3]
-            else {
-                if (downloadAttachments) {
-                    console.info("Downloading attachment", {filename: filename, url: url});
-                    browser.tabs.create({
-                        active: false,
-                        url: url
-                    })
-                    downloaded = true;
-                }
-                else {
-                    console.info(`Attachment download skipped due to user settings (downloadAttachments: false)`, {filename: filename, url: url});
-                }
-            }
-            
-            if (downloaded) {
-                // todo: [2-2]
-                console.info(`marking as successfully downloaded; filename: '${filename}', url: '${url}'`)
-                cursor.value.state = 1;
-                cursor.update(cursor.value);
-            }
-
-            cursor.continue();
+    // reset in-progress items left over from a previous session
+    let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+    store.index("state").openCursor(IDBKeyRange.only(2)).onsuccess = e => {
+        let cursor = e.target.result;
+        if (!cursor) {
+            for (let i = 0; i < concurrentDownloads; i++) downloadNext();
+            return;
         }
-    }, downloadInterval);
+        cursor.value.state = 0;
+        cursor.update(cursor.value);
+        cursor.continue();
+    };
+};
 
-    console.info(`started download interval (intervalID "${downloadIntervalId}") with "${downloadInterval}" ms interval`);
+// fires when a browser download actually completes or fails
+browser.downloads.onChanged.addListener(delta => {
+    if (!downloadIdToDbId.has(delta.id) || !delta.state) return;
+
+    let state = delta.state.current;
+    if (state !== 'complete' && state !== 'interrupted') return;
+
+    let dbId = downloadIdToDbId.get(delta.id);
+    downloadIdToDbId.delete(delta.id);
+
+    let success = state === 'complete';
+    let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+    store.get(dbId).onsuccess = e => {
+        let record = e.target.result;
+        if (record) {
+            record.state = success ? 1 : 0;
+            store.put(record);
+        }
+    };
+
+    activeDownloads--;
+    downloadNext();
+});
+
+function downloadNext() {
+    if (activeDownloads >= concurrentDownloads || !db) return;
+    activeDownloads++; // claim slot synchronously before any async work
+
+    let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+    store.index("state").openCursor(IDBKeyRange.only(0)).onsuccess = event => {
+        let cursor = event.target.result;
+        if (!cursor) {
+            activeDownloads--; // nothing pending, release slot
+            return;
+        }
+
+        let record = cursor.value;
+        record.state = 2; // mark in-progress
+        cursor.update(record);
+
+        startDownload(record.filename, record.url, record.id);
+    };
 }
-/*
- *  [2] : potential issue: a download will be signaled to have been downloaded (state = 1), 
- *  even though it is not confirmed that the download has successfully started (see [2-1], 
- *  which is in download().onsuccess method).
- *  Todo: either run the two lines following [2-2] only, if [2-1] has been run, or move
- *  the lines from below [2-2] to where [2-1] is; however, then cursor.value will be undefined. 
- * 
- *  [3] : bad ux: urls served through patreon.com/file redirect to the actual file on
- *  patreonusercontent.com per http-302; the current solution is to open a new tab
- *  with the known url and let it redirect towards the download; however, this
- *  opens a "save as" dialog to the user instead of simply downloading the file in the
- *  background.
- */
+
+function setDbState(dbId, state) {
+    let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+    store.get(dbId).onsuccess = e => {
+        let record = e.target.result;
+        if (record) { record.state = state; store.put(record); }
+    };
+}
+
+function startDownload(filename, url, dbId) {
+    console.info(`downloading; filename: '${filename}', url: '${url}'`);
+
+    if (url.includes('patreonusercontent.com')) {
+        browser.downloads.download({ filename, url, saveAs: false })
+            .then(
+                downloadId => {
+                    // slot stays claimed until onChanged fires with complete/interrupted
+                    downloadIdToDbId.set(downloadId, dbId);
+                },
+                () => {
+                    console.error(`download failed; filename: '${filename}', url: '${url}'`);
+                    setDbState(dbId, 0); // back to pending
+                    activeDownloads--;
+                    downloadNext();
+                }
+            );
+    } else if (downloadAttachments) {
+        console.info("Downloading attachment", {filename, url});
+        browser.tabs.create({ active: false, url });
+        setDbState(dbId, 1);
+        activeDownloads--;
+        downloadNext();
+    } else {
+        console.info(`Attachment skipped (downloadAttachments: false)`, {filename, url});
+        setDbState(dbId, 1);
+        activeDownloads--;
+        downloadNext();
+    }
+}

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -281,39 +281,28 @@ async function addToDownloads(creator, filename, url) {
 
     console.info(`Queueing: creator: "${creator}", filename: "${filename}", url: "${url}"`);
 
-    if (!contentCollectionEnabled) {
-        console.info(`Content collection generally disabled; queueing skipped.`);
+    if (collectionMode === "greedy" && knownCreators[creator] === false) {
+        console.info(`Collection mode greedy, but creator "${creator}" is disabled; queueing skipped.`);
         return;
     }
 
-    if (knownCreators[creator] === false) {
-        console.info(`Content collection enabled, but creator "${creator}" excluded; queueing skipped.`);
+    if (collectionMode === "selective" && knownCreators[creator] !== true) {
+        console.info(`Collection mode selective, creator "${creator}" not enabled; queueing skipped.`);
+        return;
+    }
+
+    if (!db) {
+        console.warn(`database not ready, skipping; filename: '${filename}', url: '${url}'`);
         return;
     }
 
     let identifier = determineFileIdentifier(filename, url);
 
-    if (typeof db === 'undefined') {
-        let dbOpen = window.indexedDB.open("patreonex", dbVersion);
-
-        dbOpen.onsuccess = () => {
-            db = dbOpen.result;
-            if (debug)
-                console.info("connection to database succeeded");
-        };
-
-        dbOpen.onerror = event => {
-            console.error("failed to connect to database", event);
-            return;
-        };
-    }
-
-    // check if filename already in database, add otherwise
-    let count = await db.transaction("downloads").objectStore("downloads").index("identifier").count(IDBKeyRange.only(identifier));
+    let count = db.transaction("downloads").objectStore("downloads").index("identifier").count(IDBKeyRange.only(identifier));
 
     count.onsuccess = () => {
-        if (count.result == 0) { // if not already in db
-            console.info(`adding to database; identifier: '${identifier}', filename: '${filename}', url: '${url}'`)
+        if (count.result == 0) {
+            console.info(`adding to database; identifier: '${identifier}', filename: '${filename}', url: '${url}'`);
 
             let op = db.transaction("downloads", "readwrite").objectStore("downloads").add({
                 identifier: identifier,
@@ -322,13 +311,14 @@ async function addToDownloads(creator, filename, url) {
                 state: 0
             });
 
+            op.onsuccess = () => downloadNext();
             op.onerror = () => {
-                console.error(`error adding to database; identifier: '${identifier}', filelename: '${filename}', url: '${url}'`)
+                console.error(`error adding to database; identifier: '${identifier}', filename: '${filename}', url: '${url}'`);
             };
         } else {
-            console.warn(`skipped adding to database due to count.result > 0; identifier: '${identifier}', filename '${filename}', url: '${url}'`)
+            console.warn(`skipped; already in database; identifier: '${identifier}'`);
         }
-    };   
+    };
 }
 
 function determineFileIdentifier(filename, url) {

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -281,11 +281,13 @@ async function addToDownloads(creator, filename, url) {
 
     console.info(`Queueing: creator: "${creator}", filename: "${filename}", url: "${url}"`);
 
+    // greedy: skip only creators the user explicitly disabled
     if (collectionMode === "greedy" && knownCreators[creator] === false) {
         console.info(`Collection mode greedy, but creator "${creator}" is disabled; queueing skipped.`);
         return;
     }
 
+    // selective: skip everyone not explicitly enabled via the popup
     if (collectionMode === "selective" && knownCreators[creator] !== true) {
         console.info(`Collection mode selective, creator "${creator}" not enabled; queueing skipped.`);
         return;

--- a/js/options.js
+++ b/js/options.js
@@ -14,6 +14,7 @@ var contentCollectionKnownCreators = document.getElementById("contentCollectionK
 var resetCreatorSelect = document.getElementById("resetCreatorSelect");
 var resetDownloadHistoryButton = document.getElementById("resetDownloadHistoryButton");
 var resetFeedback = document.getElementById("resetFeedback");
+var clearAllButton = document.getElementById("clearAllButton");
 // var contentCollectionClearKnownCreatorsButton = document.getElementById("contentCollectionClearKnownCreators");
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
@@ -107,39 +108,40 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 			resetCreatorSelect.appendChild(opt);
 		}
 
+		let isSelective = backgroundContext.collectionMode === "selective";
+
 		for (const name in backgroundContext.knownCreators) {
+			let enabled = backgroundContext.knownCreators[name] === true;
+
+
 			let li = document.createElement('li');
 			let label = document.createElement('label');
 			let div = document.createElement('div');
 			let input = document.createElement('input');
 			let span = document.createElement('span');
 
-			// label.innerHTML = `<input type="checkbox"${backgroundContext.knownCreators[name]? ' checked="checked"' : ''} /><span>${name}</span>`;
 			input.type = 'checkbox';
-			if (backgroundContext.knownCreators[name] === true) {
-				input.checked = true;
-			}
+			input.checked = enabled;
 
 			span.innerText = name;
-			
+
 			label.addEventListener('change', (e) => {
 				if (backgroundContext.knownCreators.hasOwnProperty(name)) {
 					backgroundContext.knownCreators[name] = e.target.checked;
 					backgroundContext.updateSettingsStorage();
 				}
 			});
-			
+
 			div.classList.add('delete-button');
-			div.addEventListener('click', (e) => {
+			div.addEventListener('click', () => {
 				if (backgroundContext.knownCreators.hasOwnProperty(name)) {
 					delete backgroundContext.knownCreators[name];
 					backgroundContext.updateSettingsStorage();
+				} else {
+					console.error(`User tried to delete creator "${name}", which was not part of knownCreators.`);
 				}
-				else {
-					console.error(`User tried to delete creator "${name}", which was not part of knownCreators.`)
-				}
-			})
-			
+			});
+
 			label.appendChild(input);
 			label.appendChild(span);
 			li.appendChild(label);
@@ -147,6 +149,24 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 			contentCollectionKnownCreators.appendChild(li);
 		}
 	}, 1000);
+
+	clearAllButton.addEventListener('click', () => {
+		if (!window.confirm('This will delete the entire download history, all known creators, and reset all settings to default. Continue?'))
+			return;
+
+		backgroundContext.db.transaction("downloads", "readwrite").objectStore("downloads").clear();
+
+		backgroundContext.knownCreators = {};
+		backgroundContext.downloadAttachments = true;
+		backgroundContext.useLostAndFound = true;
+		backgroundContext.collectionMode = "greedy";
+		backgroundContext.concurrentDownloads = 1;
+		backgroundContext.activeDownloads = 0;
+
+		browser.storage.local.clear().then(() => {
+			browser.runtime.reload();
+		});
+	});
 
 }, (error) => {
 	console.error("error loading background context:", error);

--- a/js/options.js
+++ b/js/options.js
@@ -82,6 +82,9 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 				resetFeedback.textContent = `Reset ${count} file(s) for ${label}.`;
 				resetFeedback.style.display = "block";
 				setTimeout(() => { resetFeedback.style.display = "none"; }, 4000);
+				// kick off the download queue — reset items won't trigger it automatically
+				for (let i = 0; i < backgroundContext.concurrentDownloads; i++)
+					backgroundContext.downloadNext();
 				return;
 			}
 			if (cursor.value.state === 1) {

--- a/js/options.js
+++ b/js/options.js
@@ -8,25 +8,24 @@ var useLostAndFoundCheckbox = document.getElementById("useLostAndFound");
 var debugCheckbox = document.getElementById("debug");
 var logCache = document.getElementById("logCache");
 var logCopyButton = document.getElementById("logCopy");
-var downloadIntervalInput = document.getElementById("downloadInterval");
-var contentCollectionEnabledCheckbox = document.getElementById("contentCollectionEnabledCheckbox");
+var collectionModeGreedy = document.getElementById("collectionModeGreedy");
+var collectionModeSelective = document.getElementById("collectionModeSelective");
 var contentCollectionKnownCreators = document.getElementById("contentCollectionKnownCreators");
+var resetCreatorSelect = document.getElementById("resetCreatorSelect");
+var resetDownloadHistoryButton = document.getElementById("resetDownloadHistoryButton");
+var resetFeedback = document.getElementById("resetFeedback");
 // var contentCollectionClearKnownCreatorsButton = document.getElementById("contentCollectionClearKnownCreators");
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	downloadAttachmentsCheckbox.checked = backgroundContext.downloadAttachments;
 	useLostAndFoundCheckbox.checked = backgroundContext.useLostAndFound;
 	debugCheckbox.checked = backgroundContext.debug;
-	downloadIntervalInput.value = backgroundContext.downloadInterval;
-	contentCollectionEnabledCheckbox.checked = backgroundContext.contentCollectionEnabled;
+	(backgroundContext.collectionMode === "selective" ? collectionModeSelective : collectionModeGreedy).checked = true;
+	contentCollectionKnownCreators.classList.add('open');
 
 	// open log accordion if debug is enabled
 	if (debugCheckbox.checked)
 		logCache.classList.add('open');
-
-	// open known creators list accordion if content collection is enabled
-	if (contentCollectionEnabledCheckbox.checked)
-		contentCollectionKnownCreators.classList.add('open');
 
 	downloadAttachmentsCheckbox.addEventListener('change', (event) => {
 		backgroundContext.downloadAttachments = event.target.checked;
@@ -52,23 +51,12 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 		navigator.clipboard.writeText(logCache.value);
 	});
 
-	downloadIntervalInput.addEventListener('change', (event) => {
-		event.target.value = Math.max(event.target.value, 3000);
-		event.target.value = Math.min(event.target.value, 2147483647); // signed 32 bit int
 
-		backgroundContext.downloadInterval = event.target.value;
-		backgroundContext.initializeDownloadInterval();
-		backgroundContext.updateSettingsStorage();
-	});
-
-	contentCollectionEnabledCheckbox.addEventListener('change', (event) => {
-		backgroundContext.contentCollectionEnabled = event.target.checked;
-		backgroundContext.updateSettingsStorage();
-
-		if (event.target.checked)
-			contentCollectionKnownCreators.classList.add('open');
-		else
-			contentCollectionKnownCreators.classList.remove('open');
+	[collectionModeGreedy, collectionModeSelective].forEach(radio => {
+		radio.addEventListener('change', (event) => {
+			backgroundContext.collectionMode = event.target.value;
+			backgroundContext.updateSettingsStorage();
+		});
 	});
 
 	// update log window contents
@@ -76,9 +64,49 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 		logCache.textContent = backgroundContext.log_content;
 	}, 1000);
 
+	resetDownloadHistoryButton.addEventListener('click', () => {
+		let creator = resetCreatorSelect.value;
+		let db = backgroundContext.db;
+		let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+		let count = 0;
+
+		let cursorRequest = creator === "__all__"
+			? store.openCursor()
+			: store.index("filename").openCursor(IDBKeyRange.bound(`patreon/${creator}/`, `patreon/${creator}/￿`));
+
+		cursorRequest.onsuccess = (event) => {
+			let cursor = event.target.result;
+			if (!cursor) {
+				let label = creator === "__all__" ? "all creators" : `"${creator}"`;
+				resetFeedback.textContent = `Reset ${count} file(s) for ${label}.`;
+				resetFeedback.style.display = "block";
+				setTimeout(() => { resetFeedback.style.display = "none"; }, 4000);
+				return;
+			}
+			if (cursor.value.state === 1) {
+				cursor.value.state = 0;
+				cursor.update(cursor.value);
+				count++;
+			}
+			cursor.continue();
+		};
+	});
+
 	// update known creators list
 	setInterval(() => {
 		contentCollectionKnownCreators.innerText = "";
+
+		// sync reset dropdown with known creators
+		let currentSelection = resetCreatorSelect.value;
+		while (resetCreatorSelect.options.length > 1) resetCreatorSelect.remove(1);
+		for (const name in backgroundContext.knownCreators) {
+			let opt = document.createElement('option');
+			opt.value = name;
+			opt.textContent = name;
+			if (name === currentSelection) opt.selected = true;
+			resetCreatorSelect.appendChild(opt);
+		}
+
 		for (const name in backgroundContext.knownCreators) {
 			let li = document.createElement('li');
 			let label = document.createElement('label');

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,0 +1,131 @@
+browser.runtime.getBackgroundPage().then(bg => {
+	const currentCreatorEl = document.getElementById('currentCreator');
+	const pendingCountEl = document.getElementById('pendingCount');
+	const doneCountEl = document.getElementById('doneCount');
+	const toggleCreatorBtn = document.getElementById('toggleCreatorButton');
+	const resetCreatorBtn = document.getElementById('resetCreatorButton');
+	const resetAllBtn = document.getElementById('resetAllButton');
+	const feedbackEl = document.getElementById('feedback');
+	const clearAllBtn = document.getElementById('clearAllButton');
+	const concurrentDownloadsInput = document.getElementById('concurrentDownloadsInput');
+
+	function updateCreator() {
+		let creator = bg.pageCreator;
+		if (creator) {
+			currentCreatorEl.textContent = creator;
+			currentCreatorEl.classList.remove('unknown');
+
+			let enabled = bg.knownCreators[creator] === true;
+			toggleCreatorBtn.disabled = false;
+			toggleCreatorBtn.textContent = enabled ? `Disable "${creator}"` : `Enable "${creator}"`;
+			toggleCreatorBtn.classList.toggle('secondary', enabled);
+
+			resetCreatorBtn.textContent = `Reset "${creator}"`;
+			resetCreatorBtn.disabled = false;
+		} else {
+			currentCreatorEl.textContent = 'not detected';
+			currentCreatorEl.classList.add('unknown');
+			toggleCreatorBtn.disabled = true;
+			toggleCreatorBtn.textContent = 'No creator detected';
+			toggleCreatorBtn.classList.remove('secondary');
+			resetCreatorBtn.textContent = 'Reset current creator';
+			resetCreatorBtn.disabled = true;
+		}
+	}
+
+	function updateStats() {
+		let tx = bg.db.transaction("downloads");
+		let index = tx.objectStore("downloads").index("state");
+		index.count(IDBKeyRange.only(0)).onsuccess = e => {
+			pendingCountEl.textContent = e.target.result;
+		};
+		index.count(IDBKeyRange.only(1)).onsuccess = e => {
+			doneCountEl.textContent = e.target.result;
+		};
+	}
+
+	function resetDownloads(creator) {
+		let store = bg.db.transaction("downloads", "readwrite").objectStore("downloads");
+		let count = 0;
+
+		let req = creator
+			? store.index("filename").openCursor(IDBKeyRange.bound(`patreon/${creator}/`, `patreon/${creator}/￿`))
+			: store.openCursor();
+
+		req.onsuccess = e => {
+			let cursor = e.target.result;
+			if (!cursor) {
+				let label = creator ? `"${creator}"` : 'all creators';
+				showFeedback(`Reset ${count} file(s) for ${label}.`);
+				updateStats();
+				return;
+			}
+			if (cursor.value.state === 1) {
+				cursor.value.state = 0;
+				cursor.update(cursor.value);
+				count++;
+			}
+			cursor.continue();
+		};
+	}
+
+	function showFeedback(msg) {
+		feedbackEl.textContent = msg;
+		feedbackEl.style.display = 'block';
+		setTimeout(() => { feedbackEl.style.display = 'none'; }, 4000);
+	}
+
+	concurrentDownloadsInput.value = bg.concurrentDownloads;
+	concurrentDownloadsInput.addEventListener('change', e => {
+		let val = Math.min(Math.max(parseInt(e.target.value) || 1, 1), 4);
+		e.target.value = val;
+		bg.concurrentDownloads = val;
+		bg.updateSettingsStorage();
+	});
+
+	toggleCreatorBtn.addEventListener('click', () => {
+		let creator = bg.pageCreator;
+		if (!creator) return;
+		let enabled = bg.knownCreators[creator] === true;
+		bg.setCreatorContentCollection(creator, !enabled);
+		updateCreator();
+	});
+
+	resetCreatorBtn.addEventListener('click', () => resetDownloads(bg.pageCreator));
+	resetAllBtn.addEventListener('click', () => resetDownloads(null));
+
+	clearAllBtn.addEventListener('click', () => {
+		if (!window.confirm('This will delete the entire download history, all known creators, and reset all settings to default. Continue?'))
+			return;
+
+		// clear IndexedDB
+		bg.db.transaction("downloads", "readwrite").objectStore("downloads").clear();
+
+		// reset in-memory state
+		bg.knownCreators = {};
+		bg.downloadAttachments = true;
+		bg.useLostAndFound = true;
+		bg.collectionMode = "greedy";
+		bg.concurrentDownloads = 1;
+		bg.activeDownloads = 0;
+
+		// wipe storage
+		browser.storage.local.clear().then(() => {
+			showFeedback('All data cleared. Reloading…');
+			setTimeout(() => window.close(), 1500);
+		});
+	});
+
+	browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
+		if (!tabs[0]) { updateCreator(); updateStats(); return; }
+
+		browser.tabs.sendMessage(tabs[0].id, {action: "getCreator"})
+			.then(response => {
+				if (response && response.creator) bg.pageCreator = response.creator;
+			})
+			.catch(() => {}) // not a patreon tab or content script not ready
+			.finally(() => { updateCreator(); updateStats(); });
+	});
+
+	setInterval(() => { updateCreator(); updateStats(); }, 2000);
+});

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,12 +1,7 @@
 browser.runtime.getBackgroundPage().then(bg => {
 	const currentCreatorEl = document.getElementById('currentCreator');
 	const pendingCountEl = document.getElementById('pendingCount');
-	const doneCountEl = document.getElementById('doneCount');
 	const toggleCreatorBtn = document.getElementById('toggleCreatorButton');
-	const resetCreatorBtn = document.getElementById('resetCreatorButton');
-	const resetAllBtn = document.getElementById('resetAllButton');
-	const feedbackEl = document.getElementById('feedback');
-	const clearAllBtn = document.getElementById('clearAllButton');
 	const concurrentDownloadsInput = document.getElementById('concurrentDownloadsInput');
 
 	function updateCreator() {
@@ -19,17 +14,12 @@ browser.runtime.getBackgroundPage().then(bg => {
 			toggleCreatorBtn.disabled = false;
 			toggleCreatorBtn.textContent = enabled ? `Disable "${creator}"` : `Enable "${creator}"`;
 			toggleCreatorBtn.classList.toggle('secondary', enabled);
-
-			resetCreatorBtn.textContent = `Reset "${creator}"`;
-			resetCreatorBtn.disabled = false;
 		} else {
 			currentCreatorEl.textContent = 'not detected';
 			currentCreatorEl.classList.add('unknown');
 			toggleCreatorBtn.disabled = true;
 			toggleCreatorBtn.textContent = 'No creator detected';
 			toggleCreatorBtn.classList.remove('secondary');
-			resetCreatorBtn.textContent = 'Reset current creator';
-			resetCreatorBtn.disabled = true;
 		}
 	}
 
@@ -39,40 +29,6 @@ browser.runtime.getBackgroundPage().then(bg => {
 		index.count(IDBKeyRange.only(0)).onsuccess = e => {
 			pendingCountEl.textContent = e.target.result;
 		};
-		index.count(IDBKeyRange.only(1)).onsuccess = e => {
-			doneCountEl.textContent = e.target.result;
-		};
-	}
-
-	function resetDownloads(creator) {
-		let store = bg.db.transaction("downloads", "readwrite").objectStore("downloads");
-		let count = 0;
-
-		let req = creator
-			? store.index("filename").openCursor(IDBKeyRange.bound(`patreon/${creator}/`, `patreon/${creator}/￿`))
-			: store.openCursor();
-
-		req.onsuccess = e => {
-			let cursor = e.target.result;
-			if (!cursor) {
-				let label = creator ? `"${creator}"` : 'all creators';
-				showFeedback(`Reset ${count} file(s) for ${label}.`);
-				updateStats();
-				return;
-			}
-			if (cursor.value.state === 1) {
-				cursor.value.state = 0;
-				cursor.update(cursor.value);
-				count++;
-			}
-			cursor.continue();
-		};
-	}
-
-	function showFeedback(msg) {
-		feedbackEl.textContent = msg;
-		feedbackEl.style.display = 'block';
-		setTimeout(() => { feedbackEl.style.display = 'none'; }, 4000);
 	}
 
 	concurrentDownloadsInput.value = bg.concurrentDownloads;
@@ -89,41 +45,29 @@ browser.runtime.getBackgroundPage().then(bg => {
 		let enabled = bg.knownCreators[creator] === true;
 		bg.setCreatorContentCollection(creator, !enabled);
 		updateCreator();
-	});
 
-	resetCreatorBtn.addEventListener('click', () => resetDownloads(bg.pageCreator));
-	resetAllBtn.addEventListener('click', () => resetDownloads(null));
-
-	clearAllBtn.addEventListener('click', () => {
-		if (!window.confirm('This will delete the entire download history, all known creators, and reset all settings to default. Continue?'))
-			return;
-
-		// clear IndexedDB
-		bg.db.transaction("downloads", "readwrite").objectStore("downloads").clear();
-
-		// reset in-memory state
-		bg.knownCreators = {};
-		bg.downloadAttachments = true;
-		bg.useLostAndFound = true;
-		bg.collectionMode = "greedy";
-		bg.concurrentDownloads = 1;
-		bg.activeDownloads = 0;
-
-		// wipe storage
-		browser.storage.local.clear().then(() => {
-			showFeedback('All data cleared. Reloading…');
-			setTimeout(() => window.close(), 1500);
+		// reloading the tab re-triggers API requests so newly enabled creators are collected immediately
+		if (enabled) return; // disabling needs no reload
+		browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
+			if (tabs[0]) browser.tabs.reload(tabs[0].id);
 		});
 	});
 
 	browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
 		if (!tabs[0]) { updateCreator(); updateStats(); return; }
 
+		// disable interactive controls and show a notice when not on the target site
+		let isPatreonTab = tabs[0].url && tabs[0].url.includes('patreon.com');
+		if (!isPatreonTab) {
+			document.body.classList.add('not-patreon');
+			return;
+		}
+
 		browser.tabs.sendMessage(tabs[0].id, {action: "getCreator"})
 			.then(response => {
 				if (response && response.creator) bg.pageCreator = response.creator;
 			})
-			.catch(() => {}) // not a patreon tab or content script not ready
+			.catch(() => {})
 			.finally(() => { updateCreator(); updateStats(); });
 	});
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,16 @@
 		}
 	],
 	"background": {
-		"scripts": ["js/logging.js", "js/creators.js", "js/background-main.js", "js/intercept.js", "js/download.js"]
+		"scripts": ["js/logging.js", "js/creators.js", "js/background-main.js", "js/download.js", "js/intercept.js"]
+	},
+	"browser_action": {
+		"default_popup": "popup.html",
+		"default_icon": {
+			"16": "img/pax16.png",
+			"32": "img/pax32.png",
+			"48": "img/pax48.png"
+		},
+		"default_title": "Patreon Helper"
 	},
 	"options_ui": {
 		"page": "options.html"
@@ -26,6 +35,7 @@
 	"permissions": [
 		"*://*.patreon.com/*",
 		"*://*.patreonusercontent.com/*",
+		"tabs",
 		"storage",
 		"unlimitedStorage",
 		"downloads",

--- a/options.html
+++ b/options.html
@@ -181,6 +181,14 @@
 			<button type="button" id="logCopy">copy to clipboard</button>
 			<textarea id="logCache" disabled></textarea>
 		</article>
+		<article>
+			<label style="cursor: default;">
+				<span><strong>Clear all data &amp; settings</strong>: Deletes the entire download history, all known creators, and resets all settings to their defaults. The extension will reload automatically.</span>
+			</label>
+			<div style="padding: 0 8px 16px;">
+				<button type="button" id="clearAllButton" style="background-color: #c0392b; width: auto; padding: 6px 16px;">Clear all data &amp; settings</button>
+			</div>
+		</article>
 	</main>
     <script src="js/options.js"></script>
   </body>

--- a/options.html
+++ b/options.html
@@ -136,9 +136,16 @@
 			<span><strong>Error</strong>: Your current configuration could not be loaded. It is uncertain if the settings below this message will work correctly. Please excuse the inconvenience and consider filing in a bug report at <a href="https://github.com/dogpixels/patreon-helper/issues" target="_blank">https://github.com/dogpixels/patreon-helper/issues</a>.</span>
 		</article>
 		<article>
+			<label style="cursor: default;">
+				<span><strong>Collection Mode</strong>: Controls how Patreon Helper decides which creators to collect media from.</span>
+			</label>
 			<label>
-				<input type="checkbox" id="contentCollectionEnabledCheckbox" name="contentCollectionEnabledCheckbox" />
-				<span><strong>Enable Content Collection</strong>: While checked, Patreon Helper will gather media to download as you browse Patreon. Additionally, you may uncheck individual content creators below to exclude them from content collection specifically.</span>
+				<input type="radio" name="collectionMode" id="collectionModeGreedy" value="greedy" />
+				<span><strong>Greedy</strong>: Collect media from all creators automatically. Individual creators can be disabled below.</span>
+			</label>
+			<label>
+				<input type="radio" name="collectionMode" id="collectionModeSelective" value="selective" />
+				<span><strong>Selective</strong>: Only collect media from creators you explicitly enable via the browser popup.</span>
 			</label>
 			<ul id="contentCollectionKnownCreators"></ul>
 		</article>
@@ -156,10 +163,15 @@
 		</article>
 		<article>
 			<label>
-				<span><strong>Download Interval</strong>: Interval (in milliseconds), in which to download queued media from Patreon. This interval should be higher than how long your media downloads usually take; e.g., if you regularly download large files and the download takes up to 5 seconds, an interval of at least 6000 milliseconds is recommended. Generally speaking: the higher, the safer.</span>
-				<p></p>
-				<input type="number" id="downloadInterval" name="downloadInterval" min="3000" max="2147483647" /> ms
+				<span><strong>Reset Download History</strong>: Mark files as not yet downloaded so Patreon Helper will re-download them the next time you browse that creator's page. Select a specific creator or reset everything.</span>
 			</label>
+			<div style="padding: 0 8px 16px; display: flex; gap: 8px; align-items: center;">
+				<select id="resetCreatorSelect" style="flex: 1; padding: 4px;">
+					<option value="__all__">— All Creators —</option>
+				</select>
+				<button type="button" id="resetDownloadHistoryButton">Reset</button>
+			</div>
+			<span id="resetFeedback" style="padding: 0 8px 8px; display: none; color: rgb(232, 91, 70);"></span>
 		</article>
 		<article>
 			<label>

--- a/popup.html
+++ b/popup.html
@@ -95,10 +95,23 @@
 			font-size: 12px;
 			color: #555;
 		}
+		#notPatreonNotice {
+			display: none;
+			padding: 10px 12px;
+			background: #f5f5f5;
+			color: #888;
+			font-style: italic;
+			text-align: center;
+			border-bottom: 1px solid #eee;
+		}
+		body.not-patreon #notPatreonNotice { display: block; }
+		body.not-patreon section { opacity: 0.35; pointer-events: none; }
 	</style>
 </head>
 <body>
 	<header>Patreon Helper</header>
+
+	<div id="notPatreonNotice">Not on a Patreon tab</div>
 
 	<section>
 		<div class="row">
@@ -113,10 +126,6 @@
 			<span class="label">Pending downloads</span>
 			<span class="badge pending" id="pendingCount">…</span>
 		</div>
-		<div class="row">
-			<span class="label">Downloaded</span>
-			<span class="badge done" id="doneCount">…</span>
-		</div>
 	</section>
 
 	<section>
@@ -129,13 +138,7 @@
 	</section>
 
 	<section>
-		<button id="resetCreatorButton" disabled>Reset current creator</button>
-		<button id="resetAllButton" class="secondary">Reset all creators</button>
-		<div id="feedback"></div>
-	</section>
-
-	<section>
-		<button id="clearAllButton" class="danger">Clear all data &amp; settings</button>
+		<span style="color: #aaa; font-size: 12px; font-style: italic;">To reset download history, use the addon settings page.</span>
 	</section>
 
 	<script src="js/popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style>
+		* { box-sizing: border-box; margin: 0; padding: 0; }
+		body {
+			width: 280px;
+			font-family: sans-serif;
+			font-size: 13px;
+			color: #222;
+		}
+		header {
+			background-color: rgb(232, 91, 70);
+			color: #fff;
+			padding: 10px 12px;
+			font-weight: bold;
+			font-size: 14px;
+		}
+		section {
+			padding: 10px 12px;
+			border-bottom: 1px solid #eee;
+		}
+		.row {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 4px;
+		}
+		.row:last-child { margin-bottom: 0; }
+		.label { color: #888; }
+		.value { font-weight: bold; }
+		.value.unknown { color: #bbb; font-weight: normal; font-style: italic; }
+		.badge {
+			display: inline-block;
+			background: #eee;
+			border-radius: 10px;
+			padding: 1px 8px;
+			font-size: 12px;
+		}
+		.badge.pending { background: rgb(255, 220, 100); }
+		.badge.done { background: #c8f0c8; }
+		label.toggle {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			cursor: pointer;
+		}
+		.input-row {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 8px;
+		}
+		.input-row:last-child { margin-bottom: 0; }
+		.input-row input {
+			width: 80px;
+			padding: 3px 6px;
+			border: 1px solid #ccc;
+			border-radius: 4px;
+			font-size: 13px;
+			text-align: right;
+		}
+		.unit { color: #888; font-size: 12px; margin-left: 4px; }
+		button {
+			width: 100%;
+			padding: 7px;
+			margin-top: 6px;
+			background-color: rgb(232, 91, 70);
+			color: #fff;
+			border: none;
+			border-radius: 4px;
+			cursor: pointer;
+			font-size: 13px;
+		}
+		button:hover { background-color: rgb(200, 70, 50); }
+		button:disabled {
+			background-color: #ccc;
+			cursor: default;
+		}
+		button.secondary {
+			background-color: #aaa;
+		}
+		button.secondary:hover { background-color: #888; }
+		button.danger {
+			background-color: #c0392b;
+		}
+		button.danger:hover { background-color: #922b21; }
+		#feedback {
+			display: none;
+			margin-top: 8px;
+			padding: 6px 8px;
+			background: #f0f0f0;
+			border-radius: 4px;
+			font-size: 12px;
+			color: #555;
+		}
+	</style>
+</head>
+<body>
+	<header>Patreon Helper</header>
+
+	<section>
+		<div class="row">
+			<span class="label">Current creator</span>
+			<span class="value unknown" id="currentCreator">not detected</span>
+		</div>
+		<button id="toggleCreatorButton" disabled style="margin-top: 6px;">No creator detected</button>
+	</section>
+
+	<section>
+		<div class="row">
+			<span class="label">Pending downloads</span>
+			<span class="badge pending" id="pendingCount">…</span>
+		</div>
+		<div class="row">
+			<span class="label">Downloaded</span>
+			<span class="badge done" id="doneCount">…</span>
+		</div>
+	</section>
+
+	<section>
+		<div class="input-row">
+			<span class="label">Parallel downloads</span>
+			<span>
+				<input type="number" id="concurrentDownloadsInput" min="1" max="4" />
+			</span>
+		</div>
+	</section>
+
+	<section>
+		<button id="resetCreatorButton" disabled>Reset current creator</button>
+		<button id="resetAllButton" class="secondary">Reset all creators</button>
+		<div id="feedback"></div>
+	</section>
+
+	<section>
+		<button id="clearAllButton" class="danger">Clear all data &amp; settings</button>
+	</section>
+
+	<script src="js/popup.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Changes
  
  **Popup (new)**
  - Added browser action popup with creator enable/disable button
  - Enabling a creator automatically reloads the tab so collection starts immediately
  - Shows a notice and disables controls when the active tab is not the target site
  - Reset and "Clear all data" are intentionally absent — both live in the options page
    to prevent accidental use

  **Patreon URL support**
  - Updated creator detection to match current URL formats (`/c/` and `/cw/`)
  - Added SPA navigation detection via MutationObserver so creator is re-detected
    on client-side route changes
  - Popup can query the current creator directly via message

  **Collection Mode (replaces "Enable Content Collection" checkbox)**
  - New setting in the options page: **Greedy** (collect from all creators by default,
    individual creators can be disabled) or **Selective** (only collect from creators
    explicitly enabled via the popup). Existing settings are migrated automatically.

  **Options page**
  - Collection mode radio buttons replace the old checkbox
  - Known creators list respects the current mode; checkboxes are interactive in both modes
  - Added "Clear all data & settings" button; triggers a full extension reload afterwards
    so the reset takes effect without manual intervention
  - Reset now triggers the download queue immediately after completion

  **Download engine**
  - Replaced polling interval with an event-driven approach using `browser.downloads.onChanged`
  - Downloads are now tracked by browser download ID mapped to the DB record
  - In-progress items left over from a previous session are reset on startup