### PR TITLE
fix: prevent endless download retry loop via state 3 (failed)

### DIFF
--- a/js/download.js
+++ b/js/download.js
@@ -49,12 +49,13 @@ browser.downloads.onChanged.addListener(delta => {
     let dbId = downloadIdToDbId.get(delta.id);
     downloadIdToDbId.delete(delta.id);
 
-    let success = state === 'complete';
+    // complete → done (1), interrupted → failed (3); state 3 won't be retried automatically
+    let newState = state === 'complete' ? 1 : 3;
     let store = db.transaction("downloads", "readwrite").objectStore("downloads");
     store.get(dbId).onsuccess = e => {
         let record = e.target.result;
         if (record) {
-            record.state = success ? 1 : 0;
+            record.state = newState;
             store.put(record);
         }
     };
@@ -103,7 +104,7 @@ function startDownload(filename, url, dbId) {
                 },
                 () => {
                     console.error(`download failed; filename: '${filename}', url: '${url}'`);
-                    setDbState(dbId, 0); // back to pending
+                    setDbState(dbId, 3);
                     activeDownloads--;
                     downloadNext();
                 }

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -300,25 +300,29 @@ async function addToDownloads(creator, filename, url) {
 
     let identifier = determineFileIdentifier(filename, url);
 
-    let count = db.transaction("downloads").objectStore("downloads").index("identifier").count(IDBKeyRange.only(identifier));
+    let store = db.transaction("downloads", "readwrite").objectStore("downloads");
+    let getRequest = store.index("identifier").get(IDBKeyRange.only(identifier));
 
-    count.onsuccess = () => {
-        if (count.result == 0) {
+    getRequest.onsuccess = () => {
+        let record = getRequest.result;
+
+        if (!record) {
             console.info(`adding to database; identifier: '${identifier}', filename: '${filename}', url: '${url}'`);
-
-            let op = db.transaction("downloads", "readwrite").objectStore("downloads").add({
-                identifier: identifier,
-                filename: filename,
-                url: url,
-                state: 0
-            });
-
+            let op = store.add({ identifier, filename, url, state: 0 });
             op.onsuccess = () => downloadNext();
             op.onerror = () => {
                 console.error(`error adding to database; identifier: '${identifier}', filename: '${filename}', url: '${url}'`);
             };
+        } else if (record.state === 3 && record.url !== url) {
+            // previously failed, but Patreon provided a fresh url — update and retry
+            console.info(`previously failed, fresh url detected — resetting; identifier: '${identifier}'`);
+            record.url = url;
+            record.state = 0;
+            let op = store.put(record);
+            op.onsuccess = () => downloadNext();
         } else {
-            console.warn(`skipped; already in database; identifier: '${identifier}'`);
+            // already known (pending, in-progress, done, or failed with same url) — skip
+            console.warn(`skipped; already in database; identifier: '${identifier}', state: ${record.state}`);
         }
     };
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,6 +1,8 @@
 browser.runtime.getBackgroundPage().then(bg => {
 	const currentCreatorEl = document.getElementById('currentCreator');
 	const pendingCountEl = document.getElementById('pendingCount');
+	const failedCountEl = document.getElementById('failedCount');
+	const clearFailedButton = document.getElementById('clearFailedButton');
 	const toggleCreatorBtn = document.getElementById('toggleCreatorButton');
 	const concurrentDownloadsInput = document.getElementById('concurrentDownloadsInput');
 	const openSettingsPageEl = document.getElementById('openSettingsPageLink');
@@ -30,7 +32,23 @@ browser.runtime.getBackgroundPage().then(bg => {
 		index.count(IDBKeyRange.only(0)).onsuccess = e => {
 			pendingCountEl.textContent = e.target.result;
 		};
+		index.count(IDBKeyRange.only(3)).onsuccess = e => {
+			failedCountEl.textContent = e.target.result;
+			clearFailedButton.disabled = e.target.result === 0;
+		};
 	}
+
+	// state 3 is self-healing — intercept.js resets it automatically when Patreon serves a fresh url on the next visit;
+	// Clear removes entries manually so they can be re-collected from scratch
+	clearFailedButton.addEventListener('click', () => {
+		let store = bg.db.transaction("downloads", "readwrite").objectStore("downloads");
+		store.index("state").openCursor(IDBKeyRange.only(3)).onsuccess = e => {
+			let cursor = e.target.result;
+			if (!cursor) { updateStats(); return; }
+			cursor.delete();
+			cursor.continue();
+		};
+	});
 
 	concurrentDownloadsInput.value = bg.concurrentDownloads;
 	concurrentDownloadsInput.addEventListener('change', e => {

--- a/popup.html
+++ b/popup.html
@@ -40,6 +40,7 @@
 		}
 		.badge.pending { background: rgb(255, 220, 100); }
 		.badge.done { background: #c8f0c8; }
+		.badge.failed { background: #f5c6c2; }
 		label.toggle {
 			display: flex;
 			align-items: center;
@@ -125,6 +126,13 @@
 		<div class="row">
 			<span class="label">Pending downloads</span>
 			<span class="badge pending" id="pendingCount">…</span>
+		</div>
+		<div class="row">
+			<span class="label">Failed downloads</span>
+			<span style="display:flex;align-items:center;gap:6px;">
+				<span class="badge failed" id="failedCount">…</span>
+				<button id="clearFailedButton" style="width:auto;margin-top:0;padding:2px 8px;font-size:12px;">Clear</button>
+			</span>
 		</div>
 	</section>
 


### PR DESCRIPTION
## Problem

When a download failed (expired URL, network error, etc.), the extension reset the entry back to `state: 0` and immediately retried - with no limit. This caused an endless loop that  could not be stopped without clearing the entire database.

## Solution

Introduces `state: 3` as a permanent failed state.

**`download.js`**
Both failure paths (`onChanged: interrupted` and `browser.downloads.download()` rejection) now set the record to `state: 3` instead of `state: 0`. State 3 entries are never picked up by  `downloadNext()`, breaking the loop.

**`intercept.js`**
`addToDownloads` was refactored from a `count()` check to a `get()` lookup so the actual record can be inspected. When a state 3 entry is encountered and Patreon provides a different URL  (i.e. a fresh session), the record is updated with the new URL and reset to `state: 0` for retry. This makes failed downloads self-healing — no manual intervention needed in the normal case.

**`popup.js` / `popup.html`**
- Failed downloads counter (state 3) added to the popup
- "Clear" button removes all state 3 entries from the database, allowing them to be re-collected from scratch on the next Patreon visit
- Clear button is disabled when the failed count is 0

## State overview

| State | Meaning |
|-------|---------|
| `0` | Pending |
| `1` | Done |
| `2` | In progress |
| `3` | Failed (permanent, self-healing on fresh URL) |