### PR TITLE
fix: delete reset-history records instead of re-flagging them

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -79,17 +79,17 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 			let cursor = event.target.result;
 			if (!cursor) {
 				let label = creator === "__all__" ? "all creators" : `"${creator}"`;
-				resetFeedback.textContent = `Reset ${count} file(s) for ${label}.`;
+				resetFeedback.textContent = `Cleared ${count} file(s) from history for ${label}. They will be re-downloaded with a fresh URL the next time you browse them.`;
 				resetFeedback.style.display = "block";
 				setTimeout(() => { resetFeedback.style.display = "none"; }, 4000);
-				// kick off the download queue — reset items won't trigger it automatically
-				for (let i = 0; i < backgroundContext.concurrentDownloads; i++)
-					backgroundContext.downloadNext();
 				return;
 			}
-			if (cursor.value.state === 1) {
-				cursor.value.state = 0;
-				cursor.update(cursor.value);
+			// drop only finished (1) and failed (3) records; leave pending (0) and in-progress (2)
+			// so the active download queue isn't disturbed. removing the record (rather than resetting
+			// its state) means the stale, expired url is gone too — the next browse re-adds the file
+			// fresh via the !record branch in intercept.js, so no doomed download with a dead token.
+			if (cursor.value.state === 1 || cursor.value.state === 3) {
+				cursor.delete();
 				count++;
 			}
 			cursor.continue();

--- a/options.html
+++ b/options.html
@@ -154,13 +154,13 @@
 		</article>
 		<article>
 			<label>
-				<span><strong>Reset Download History</strong>: Mark files as not yet downloaded so Patreon Helper will re-download them the next time you browse that creator's page. Select a specific creator or reset everything.</span>
+				<span><strong>Reset Download History</strong>: Forget that files were already downloaded so Patreon Helper will re-download them the next time you browse that creator's page. The stored entries are removed (not just re-flagged), so the file is re-fetched with a fresh URL. Select a specific creator or reset everything.</span>
 			</label>
 			<div style="padding: 0 8px 16px; display: flex; gap: 8px; align-items: center;">
 				<select id="resetCreatorSelect" style="flex: 1; padding: 4px;">
 					<option value="__all__">— All Creators —</option>
 				</select>
-				<button type="button" id="resetDownloadHistoryButton">Reset</button>
+				<button type="button" id="resetDownloadHistoryButton">Clear History</button>
 			</div>
 			<span id="resetFeedback" style="padding: 0 8px 8px; display: none; color: rgb(232, 91, 70);"></span>
 		</article>


### PR DESCRIPTION
Resetting completed files to state 0 and immediately starting the queue re-attempted downloads with the stored url, whose patreonusercontent.com token has expired since it was captured — so those downloads failed and the records were downgraded to state 3.

Delete the finished (1) and failed (3) records instead. Pending (0) and in-progress (2) records are left alone so the active queue isn't disturbed. With the stale url gone, the next browse re-adds the file fresh via the !record branch in intercept.js and re-fetches it with a valid token.