### PR TITLE
Media download settings: file-type filter, folder structure & ID-based identification (2.3)

### DIFF
--- a/js/background-main.js
+++ b/js/background-main.js
@@ -8,7 +8,7 @@ var dbVersion = 3;
 
 /* options */
 var downloadAttachments = true; // attachments currently only download with a "Save As" dialog; If false, these files will be ignored.
-var useLostAndFound = true; // attachments with file_name = null will be downloaded with a random generated file name to {ArtistName}_{LostAndFoundSuffix}
+var useLostAndFound = true; // media with file_name = null will be downloaded with a random generated file name into <creator>/LostAndFound/
 // "greedy": collect from all creators by default, individual creators can be disabled
 // "selective": only collect from creators explicitly enabled via the popup
 var collectionMode = "greedy";
@@ -144,15 +144,19 @@ var mediaTypeFolders = {
 
 // builds the full relative download path for a file. in "byType" mode a media-type
 // subfolder is inserted between the creator folder and the file (<creator>/images/foo.png).
+// when lostAndFound is set, the file goes into the dedicated <creator>/LostAndFound/
+// subfolder instead (and is not split by type, since its name is only guessed).
 // fileName is expected to already be a bare file name (see baseName).
-function buildDownloadPath(creator, fileName, url) {
+function buildDownloadPath(creator, fileName, url, lostAndFound) {
 	let path = downloadPrefix + creator + "/";
-	if (storageMode === "byType")
+	if (lostAndFound)
+		path += LostAndFoundFolder + "/";
+	else if (storageMode === "byType")
 		path += (mediaTypeFolders[getMediaType(fileName, url)] || 'other') + "/";
 	return path + fileName;
 }
 var unknownCreator = "_unknown";
-var LostAndFoundSuffix = "_LostAndFound"
+var LostAndFoundFolder = "LostAndFound";
 
 console.info("patreon helper 1.15 loaded");
 

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -92,6 +92,14 @@ var mediaTypeGroups = {
 // flattened for plain "does this link point at a media file" checks (post content link extraction)
 var mediaExtensions = Object.values(mediaTypeGroups).flat();
 
+// strips any leading directory path from a file name, keeping only the final component.
+// patreon sometimes ships file names that contain a leading path, which would otherwise
+// create unwanted subfolders under the creator directory.
+function baseName(name) {
+	if (!name) return name;
+	return name.split(/[\\/]/).pop();
+}
+
 // pulls the file extension from a file name or url (ignores #fragment and ?query), lowercased
 function fileExtensionOf(s) {
 	if (!s) return null;

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -16,6 +16,8 @@ var knownCreators = {};
 // "everything": download every file type. "selected": only download the groups enabled in mediaTypes.
 var mediaTypeMode = "everything";
 var mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };
+// "flat": store files directly under <creator>/. "byType": sort into <creator>/images, <creator>/videos, ...
+var storageMode = "flat";
 
 browser.storage.local.get('settings').then((result) => {
 	if (result.hasOwnProperty('settings')) {
@@ -44,6 +46,9 @@ browser.storage.local.get('settings').then((result) => {
 		if (result.settings.hasOwnProperty('mediaTypes'))
 			mediaTypes = Object.assign(mediaTypes, result.settings.mediaTypes);
 
+		if (result.settings.hasOwnProperty('storageMode'))
+			storageMode = result.settings.storageMode;
+
 		if (result.settings.hasOwnProperty('concurrentDownloads'))
 			concurrentDownloads = result.settings.concurrentDownloads;
 	}
@@ -62,6 +67,7 @@ function updateSettingsStorage() {
 		knownCreators: knownCreators,
 		mediaTypeMode: mediaTypeMode,
 		mediaTypes: mediaTypes,
+		storageMode: storageMode,
 		concurrentDownloads: concurrentDownloads
 	}
 
@@ -128,6 +134,22 @@ function isMediaTypeEnabled(filename, url) {
 	if (type === 'unknown')
 		return true;
 	return mediaTypes[type] === true;
+}
+
+// subfolder names used when storageMode is "byType"; unrecognized types land in "other"
+var mediaTypeFolders = {
+	image: 'images', video: 'videos', audio: 'audio',
+	document: 'documents', font: 'fonts', archive: 'archives', unknown: 'other'
+};
+
+// builds the full relative download path for a file. in "byType" mode a media-type
+// subfolder is inserted between the creator folder and the file (<creator>/images/foo.png).
+// fileName is expected to already be a bare file name (see baseName).
+function buildDownloadPath(creator, fileName, url) {
+	let path = downloadPrefix + creator + "/";
+	if (storageMode === "byType")
+		path += (mediaTypeFolders[getMediaType(fileName, url)] || 'other') + "/";
+	return path + fileName;
 }
 var unknownCreator = "_unknown";
 var LostAndFoundSuffix = "_LostAndFound"

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -8,7 +8,6 @@ var dbVersion = 3;
 
 /* options */
 var downloadAttachments = true; // attachments currently only download with a "Save As" dialog; If false, these files will be ignored.
-var useLostAndFound = true; // media with file_name = null will be downloaded with a random generated file name into <creator>/LostAndFound/
 // "greedy": collect from all creators by default, individual creators can be disabled
 // "selective": only collect from creators explicitly enabled via the popup
 var collectionMode = "greedy";
@@ -24,9 +23,6 @@ browser.storage.local.get('settings').then((result) => {
 		if (result.settings.hasOwnProperty('downloadAttachments'))
 			downloadAttachments = result.settings.downloadAttachments;
 		
-		if (result.settings.hasOwnProperty('useLostAndFound'))
-			useLostAndFound = result.settings.useLostAndFound;
-	
 		if (result.settings.hasOwnProperty('debug'))
 			debug = result.settings.debug;
 	
@@ -61,7 +57,6 @@ browser.storage.local.get('settings').then((result) => {
 function updateSettingsStorage() {
 	let settings = {
 		downloadAttachments: downloadAttachments,
-		useLostAndFound: useLostAndFound,
 		debug: debug,
 		collectionMode: collectionMode,
 		knownCreators: knownCreators,
@@ -144,19 +139,14 @@ var mediaTypeFolders = {
 
 // builds the full relative download path for a file. in "byType" mode a media-type
 // subfolder is inserted between the creator folder and the file (<creator>/images/foo.png).
-// when lostAndFound is set, the file goes into the dedicated <creator>/LostAndFound/
-// subfolder instead (and is not split by type, since its name is only guessed).
 // fileName is expected to already be a bare file name (see baseName).
-function buildDownloadPath(creator, fileName, url, lostAndFound) {
+function buildDownloadPath(creator, fileName, url) {
 	let path = downloadPrefix + creator + "/";
-	if (lostAndFound)
-		path += LostAndFoundFolder + "/";
-	else if (storageMode === "byType")
+	if (storageMode === "byType")
 		path += (mediaTypeFolders[getMediaType(fileName, url)] || 'other') + "/";
 	return path + fileName;
 }
 var unknownCreator = "_unknown";
-var LostAndFoundFolder = "LostAndFound";
 
 console.info("patreon helper 1.15 loaded");
 

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -13,6 +13,9 @@ var useLostAndFound = true; // attachments with file_name = null will be downloa
 // "selective": only collect from creators explicitly enabled via the popup
 var collectionMode = "greedy";
 var knownCreators = {};
+// "everything": download every file type. "selected": only download the groups enabled in mediaTypes.
+var mediaTypeMode = "everything";
+var mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };
 
 browser.storage.local.get('settings').then((result) => {
 	if (result.hasOwnProperty('settings')) {
@@ -34,6 +37,13 @@ browser.storage.local.get('settings').then((result) => {
 		if (result.settings.hasOwnProperty('knownCreators'))
 			knownCreators = result.settings.knownCreators;
 
+		if (result.settings.hasOwnProperty('mediaTypeMode'))
+			mediaTypeMode = result.settings.mediaTypeMode;
+
+		// merge so groups added in future versions still default to enabled
+		if (result.settings.hasOwnProperty('mediaTypes'))
+			mediaTypes = Object.assign(mediaTypes, result.settings.mediaTypes);
+
 		if (result.settings.hasOwnProperty('concurrentDownloads'))
 			concurrentDownloads = result.settings.concurrentDownloads;
 	}
@@ -50,6 +60,8 @@ function updateSettingsStorage() {
 		debug: debug,
 		collectionMode: collectionMode,
 		knownCreators: knownCreators,
+		mediaTypeMode: mediaTypeMode,
+		mediaTypes: mediaTypes,
 		concurrentDownloads: concurrentDownloads
 	}
 
@@ -69,13 +81,46 @@ function updateSettingsStorage() {
  /* download */
 var concurrentDownloads = 1;
 var downloadPrefix = 'patreon/';
-var mediaExtensions = [
-	'png', 'gif', 'jpg', 'jpeg', 'bmp', 'ai', 'ps', 'svg', 'tif', 'tiff', 'ico', 							// image
-	'mp4', 'webm', 'avi', 'mpg', 'mpeg', 'swf', 'flv', '3gp', '3g2', 'h264', 'mkv', 'mov', 'm4v', 'wmv', 	// video 
-	'ttf', 'otf', 'fon', 'fnt', 																			// font
-	'mp3', 'ogg', 'wav', 'wma', 'mpa', 'mid', 'midi', 'cda', 'aif', 										// sound
-	'zip', '7z', 'rar', 'tar.gz', 'z' 																		// compressed files
-];
+var mediaTypeGroups = {
+	image:    ['png', 'gif', 'jpg', 'jpeg', 'bmp', 'ai', 'ps', 'svg', 'tif', 'tiff', 'ico'],
+	video:    ['mp4', 'webm', 'avi', 'mpg', 'mpeg', 'swf', 'flv', '3gp', '3g2', 'h264', 'mkv', 'mov', 'm4v', 'wmv'],
+	audio:    ['mp3', 'ogg', 'wav', 'wma', 'mpa', 'mid', 'midi', 'cda', 'aif'],
+	document: ['pdf', 'doc', 'docx', 'odt', 'rtf', 'txt', 'md', 'epub'],
+	font:     ['ttf', 'otf', 'fon', 'fnt'],
+	archive:  ['zip', '7z', 'rar', 'tar.gz', 'z']
+};
+// flattened for plain "does this link point at a media file" checks (post content link extraction)
+var mediaExtensions = Object.values(mediaTypeGroups).flat();
+
+// pulls the file extension from a file name or url (ignores #fragment and ?query), lowercased
+function fileExtensionOf(s) {
+	if (!s) return null;
+	let base = s.split('#')[0].split('?')[0];
+	let match = base.match(/\.([a-z0-9]+)$/i);
+	return match ? match[1].toLowerCase() : null;
+}
+
+// classifies a download by its file extension into one of the mediaTypeGroups, or 'unknown'
+function getMediaType(filename, url) {
+	let ext = fileExtensionOf(filename) || fileExtensionOf(url);
+	if (!ext)
+		return 'unknown';
+	for (let group in mediaTypeGroups)
+		if (mediaTypeGroups[group].includes(ext))
+			return group;
+	return 'unknown';
+}
+
+// applies the user's "Download File Types" setting. unknown types are always allowed (fail-open),
+// so the filter only ever removes clearly-categorized groups the user explicitly disabled.
+function isMediaTypeEnabled(filename, url) {
+	if (mediaTypeMode !== "selected")
+		return true;
+	let type = getMediaType(filename, url);
+	if (type === 'unknown')
+		return true;
+	return mediaTypes[type] === true;
+}
 var unknownCreator = "_unknown";
 var LostAndFoundSuffix = "_LostAndFound"
 

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -1,4 +1,4 @@
-/*	
+/*
  *	Patreon Helper for Firefox
  * 	draconigen@gmail.com
  */
@@ -17,15 +17,40 @@ var mediaTypeMode = "everything";
 var mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };
 // "flat": store files directly under <creator>/. "byType": sort into <creator>/images, <creator>/videos, ...
 var storageMode = "flat";
+var concurrentDownloads = 1;
+
+/* download */
+var downloadPrefix = 'patreon/';
+var mediaTypeGroups = {
+	image:    ['png', 'gif', 'jpg', 'jpeg', 'bmp', 'ai', 'ps', 'svg', 'tif', 'tiff', 'ico'],
+	video:    ['mp4', 'webm', 'avi', 'mpg', 'mpeg', 'swf', 'flv', '3gp', '3g2', 'h264', 'mkv', 'mov', 'm4v', 'wmv'],
+	audio:    ['mp3', 'ogg', 'wav', 'wma', 'mpa', 'mid', 'midi', 'cda', 'aif'],
+	document: ['pdf', 'doc', 'docx', 'odt', 'rtf', 'txt', 'md', 'epub'],
+	font:     ['ttf', 'otf', 'fon', 'fnt'],
+	archive:  ['zip', '7z', 'rar', 'tar.gz', 'z']
+};
+// flattened for plain "does this link point at a media file" checks (post content link extraction)
+var mediaExtensions = Object.values(mediaTypeGroups).flat();
+// subfolder names used when storageMode is "byType"; unrecognized types land in "other"
+var mediaTypeFolders = {
+	image: 'images', video: 'videos', audio: 'audio',
+	document: 'documents', font: 'fonts', archive: 'archives', unknown: 'other'
+};
+var unknownCreator = "_unknown";
+
+/* state */
+var pageCreator = null;
+
+console.info("patreon helper loaded");
 
 browser.storage.local.get('settings').then((result) => {
 	if (result.hasOwnProperty('settings')) {
 		if (result.settings.hasOwnProperty('downloadAttachments'))
 			downloadAttachments = result.settings.downloadAttachments;
-		
+
 		if (result.settings.hasOwnProperty('debug'))
 			debug = result.settings.debug;
-	
+
 		if (result.settings.hasOwnProperty('collectionMode'))
 			collectionMode = result.settings.collectionMode;
 		else if (result.settings.hasOwnProperty('contentCollectionEnabled'))
@@ -72,26 +97,12 @@ function updateSettingsStorage() {
 	.then(
 		() => {
 			// console.info('wrote settings to localStorage:', settings);
-		}, 
+		},
 		(error) => {
 			console.error('failed to write settings to localStorage, details:', error);
 		}
 	);
 }
-
- /* download */
-var concurrentDownloads = 1;
-var downloadPrefix = 'patreon/';
-var mediaTypeGroups = {
-	image:    ['png', 'gif', 'jpg', 'jpeg', 'bmp', 'ai', 'ps', 'svg', 'tif', 'tiff', 'ico'],
-	video:    ['mp4', 'webm', 'avi', 'mpg', 'mpeg', 'swf', 'flv', '3gp', '3g2', 'h264', 'mkv', 'mov', 'm4v', 'wmv'],
-	audio:    ['mp3', 'ogg', 'wav', 'wma', 'mpa', 'mid', 'midi', 'cda', 'aif'],
-	document: ['pdf', 'doc', 'docx', 'odt', 'rtf', 'txt', 'md', 'epub'],
-	font:     ['ttf', 'otf', 'fon', 'fnt'],
-	archive:  ['zip', '7z', 'rar', 'tar.gz', 'z']
-};
-// flattened for plain "does this link point at a media file" checks (post content link extraction)
-var mediaExtensions = Object.values(mediaTypeGroups).flat();
 
 // strips any leading directory path from a file name, keeping only the final component.
 // patreon sometimes ships file names that contain a leading path, which would otherwise
@@ -131,12 +142,6 @@ function isMediaTypeEnabled(filename, url) {
 	return mediaTypes[type] === true;
 }
 
-// subfolder names used when storageMode is "byType"; unrecognized types land in "other"
-var mediaTypeFolders = {
-	image: 'images', video: 'videos', audio: 'audio',
-	document: 'documents', font: 'fonts', archive: 'archives', unknown: 'other'
-};
-
 // builds the full relative download path for a file. in "byType" mode a media-type
 // subfolder is inserted between the creator folder and the file (<creator>/images/foo.png).
 // fileName is expected to already be a bare file name (see baseName).
@@ -146,11 +151,7 @@ function buildDownloadPath(creator, fileName, url) {
 		path += (mediaTypeFolders[getMediaType(fileName, url)] || 'other') + "/";
 	return path + fileName;
 }
-var unknownCreator = "_unknown";
 
-console.info("patreon helper 1.15 loaded");
-
-var pageCreator = null;
 browser.runtime.onMessage.addListener((request, sender) => {
 	console.info(`Runtime Message received. Action: "${request.action}" from ${sender.tab.active? "active ": ""}tab with url "${sender.tab.url}"`, request);
 

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -8,6 +8,8 @@ var streamUrls = [
     '*://*.patreon.com/api/posts*'
 ];
 var identifierRegex = /\/post\/\d*\/(\w*)\/|file\?(h\=\d*\&i\=\w*)/;
+var db;
+var names = {};
 
 // extracts the creator's vanity slug from any patreon profile/checkout/join url
 function extractVanityFromUrl(url) {
@@ -56,9 +58,6 @@ function resolveCreatorName(post, response) {
     // last resort: the creator detected from the page url, else unknown
     return pageCreator ? pageCreator : unknownCreator;
 }
-
-var db;
-var names = {};
 
 function interceptStreamResponse(details) {
     console.info(`intercepting api request id '${details.requestId}'`);

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -249,9 +249,9 @@ function extractDownloadInfo(response) {
     
             // /api/stream
             if (
-                incl.type == "media" && 
+                incl.type == "media" &&
                 incl.hasOwnProperty('attributes') &&
-                incl.attributes.hasOwnProperty('download_url') && 
+                incl.attributes.download_url != null && // null for streaming (e.g. Mux/.m3u8) media, which can't be downloaded directly
                 incl.attributes.hasOwnProperty('file_name')
             ) {
                 let name = pageCreator? pageCreator : unknownCreator;
@@ -339,6 +339,12 @@ async function addToDownloads(creator, filename, url) {
     // selective: skip everyone not explicitly enabled via the popup
     if (collectionMode === "selective" && knownCreators[creator] !== true) {
         console.info(`Collection mode selective, creator "${creator}" not enabled; queueing skipped.`);
+        return;
+    }
+
+    // "Download File Types" filter: skip groups the user disabled in the options page
+    if (!isMediaTypeEnabled(filename, url)) {
+        console.info(`media type "${getMediaType(filename, url)}" is disabled; queueing skipped for filename: '${filename}'`);
         return;
     }
 

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -266,7 +266,10 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.download_url
                 });
 
-                // workaround for when patreon started to null attributes.file_name somewhen in 03/2020
+                // workaround for when patreon started to null attributes.file_name somewhen in 03/2020.
+                // the creator name stays unchanged so registration and selective-mode filtering still
+                // match the real creator; these uncertain files just land in a <creator>/LostAndFound/ subfolder.
+                let lostAndFound = false;
                 if (incl.attributes.file_name == null) {
                     if (!useLostAndFound) {
                         console.warn(`/{file_name} was null, but user setting useLostAndFound is disabled; operation skipped`)
@@ -274,11 +277,11 @@ function extractDownloadInfo(response) {
                     }
 
                     incl.attributes.file_name = new Date().getTime() + '-' + Math.floor(Math.random() * 1024) + '.jpg';
-                    name += LostAndFoundSuffix;
+                    lostAndFound = true;
                     console.warn(`/{file_name} was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url), incl.attributes.download_url);
+                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url, lostAndFound), incl.attributes.download_url);
             }
 
             // attachments

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -147,7 +147,7 @@ function extractDownloadInfo(response) {
                     console.warn(`the aforementioned media on post has been identified affected by 07/2020 Nikofix and has been skipped`);
                 }
                 else {
-                    addToDownloads(name, downloadPrefix + name + "/" + baseName(data.attributes.post_file.name), data.attributes.post_file.url);
+                    addToDownloads(name, buildDownloadPath(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url), data.attributes.post_file.url);
                 }
             }
 
@@ -156,7 +156,8 @@ function extractDownloadInfo(response) {
                 console.log(`'content' found in post response; searching for media links; data.attributes.content:`, data.attributes.content);
                 findMediaUrls(data.attributes.content).forEach(url => {
                     console.info(`url found in post content, url:`, url);
-                    addToDownloads(name, downloadPrefix + name + "/" + url.split('/').pop().split('#')[0].split('?')[0], url);
+                    let file = url.split('/').pop().split('#')[0].split('?')[0];
+                    addToDownloads(name, buildDownloadPath(name, file, url), url);
                 });
             }
 
@@ -277,7 +278,7 @@ function extractDownloadInfo(response) {
                     console.warn(`/{file_name} was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, `${downloadPrefix}${name}/${baseName(incl.attributes.file_name)}`, incl.attributes.download_url);
+                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url), incl.attributes.download_url);
             }
 
             // attachments
@@ -298,7 +299,7 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.url
                 });
 
-                addToDownloads(name, downloadPrefix + name + "/" + baseName(incl.attributes.name), incl.attributes.url);
+                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.name), incl.attributes.url), incl.attributes.url);
             }
         });
     }

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -147,7 +147,7 @@ function extractDownloadInfo(response) {
                     console.warn(`the aforementioned media on post has been identified affected by 07/2020 Nikofix and has been skipped`);
                 }
                 else {
-                    addToDownloads(name, buildDownloadPath(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url), data.attributes.post_file.url, objectIdentifier("media", data.attributes.post_file.media_id));
+                    addToDownloads(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url, objectIdentifier("media", data.attributes.post_file.media_id));
                 }
             }
 
@@ -157,7 +157,7 @@ function extractDownloadInfo(response) {
                 findMediaUrls(data.attributes.content).forEach(url => {
                     console.info(`url found in post content, url:`, url);
                     let file = url.split('/').pop().split('#')[0].split('?')[0];
-                    addToDownloads(name, buildDownloadPath(name, file, url), url);
+                    addToDownloads(name, file, url);
                 });
             }
 
@@ -274,7 +274,7 @@ function extractDownloadInfo(response) {
                     console.warn(`file_name was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url), incl.attributes.download_url, objectIdentifier("media", incl.id));
+                addToDownloads(name, baseName(incl.attributes.file_name), incl.attributes.download_url, objectIdentifier("media", incl.id));
             }
 
             // attachments
@@ -295,7 +295,7 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.url
                 });
 
-                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.name), incl.attributes.url), incl.attributes.url, objectIdentifier("attachment", incl.id));
+                addToDownloads(name, baseName(incl.attributes.name), incl.attributes.url, objectIdentifier("attachment", incl.id));
             }
         });
     }
@@ -322,8 +322,12 @@ function findMediaUrls(text) {
     return ret;
 }
 
-async function addToDownloads(creator, filename, url, identifier) {
+async function addToDownloads(creator, fileName, url, identifier) {
     registerCreator(creator);
+
+    // build the on-disk path here so callers only pass the bare file name (and don't
+    // have to repeat creator/url for buildDownloadPath on top of passing them to us)
+    let filename = buildDownloadPath(creator, fileName, url);
 
     console.info(`Queueing: creator: "${creator}", filename: "${filename}", url: "${url}"`);
 

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -147,7 +147,7 @@ function extractDownloadInfo(response) {
                     console.warn(`the aforementioned media on post has been identified affected by 07/2020 Nikofix and has been skipped`);
                 }
                 else {
-                    addToDownloads(name, buildDownloadPath(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url), data.attributes.post_file.url);
+                    addToDownloads(name, buildDownloadPath(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url), data.attributes.post_file.url, objectIdentifier("media", data.attributes.post_file.media_id));
                 }
             }
 
@@ -266,22 +266,15 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.download_url
                 });
 
-                // workaround for when patreon started to null attributes.file_name somewhen in 03/2020.
-                // the creator name stays unchanged so registration and selective-mode filtering still
-                // match the real creator; these uncertain files just land in a <creator>/LostAndFound/ subfolder.
-                let lostAndFound = false;
+                // patreon nulls attributes.file_name for some media (since ~03/2020). we still have a
+                // stable media id, so name the file after it (<id>.<ext>) and treat it like any other
+                // download. the extension is taken from the url, since the original name is unknown.
                 if (incl.attributes.file_name == null) {
-                    if (!useLostAndFound) {
-                        console.warn(`/{file_name} was null, but user setting useLostAndFound is disabled; operation skipped`)
-                        return;
-                    }
-
-                    incl.attributes.file_name = new Date().getTime() + '-' + Math.floor(Math.random() * 1024) + '.jpg';
-                    lostAndFound = true;
-                    console.warn(`/{file_name} was null, replaced it by '${incl.attributes.file_name}'`);
+                    incl.attributes.file_name = incl.id + "." + (fileExtensionOf(incl.attributes.download_url) || "jpg");
+                    console.warn(`file_name was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url, lostAndFound), incl.attributes.download_url);
+                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.file_name), incl.attributes.download_url), incl.attributes.download_url, objectIdentifier("media", incl.id));
             }
 
             // attachments
@@ -302,7 +295,7 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.url
                 });
 
-                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.name), incl.attributes.url), incl.attributes.url);
+                addToDownloads(name, buildDownloadPath(name, baseName(incl.attributes.name), incl.attributes.url), incl.attributes.url, objectIdentifier("attachment", incl.id));
             }
         });
     }
@@ -329,10 +322,18 @@ function findMediaUrls(text) {
     return ret;
 }
 
-async function addToDownloads(creator, filename, url) {
+async function addToDownloads(creator, filename, url, identifier) {
     registerCreator(creator);
 
     console.info(`Queueing: creator: "${creator}", filename: "${filename}", url: "${url}"`);
+
+    // Mux-hosted video (stream.mux.com / image.mux.com) uses player-only signed tokens; a direct
+    // fetch returns {"error":...,"type":"not_authorized"}. these can't be downloaded as a plain file,
+    // and since the host isn't patreonusercontent.com they'd otherwise be opened in a useless tab.
+    if (url && url.includes('mux.com')) {
+        console.info(`Mux URL is not directly downloadable; queueing skipped; url: '${url}'`);
+        return;
+    }
 
     // greedy: skip only creators the user explicitly disabled
     if (collectionMode === "greedy" && knownCreators[creator] === false) {
@@ -357,7 +358,10 @@ async function addToDownloads(creator, filename, url) {
         return;
     }
 
-    let identifier = determineFileIdentifier(filename, url);
+    // prefer a stable Patreon object id (media/attachment) as the dedup key when the caller
+    // provides one; only external links scraped from post text fall back to parsing the url.
+    if (!identifier)
+        identifier = determineFileIdentifier(filename, url);
 
     let store = db.transaction("downloads", "readwrite").objectStore("downloads");
     let getRequest = store.index("identifier").get(IDBKeyRange.only(identifier));
@@ -410,6 +414,12 @@ function determineFileIdentifier(filename, url) {
     // that should not occur
     console.error("identifier search: unhandled matches, filename will be used; matches:", matches);
     return filename;
+}
+
+// builds a stable dedup identifier from a Patreon object id (e.g. "media-672366612"),
+// or undefined when no id is available (then the caller falls back to the url).
+function objectIdentifier(type, id) {
+    return id != null ? type + "-" + id : undefined;
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -147,7 +147,7 @@ function extractDownloadInfo(response) {
                     console.warn(`the aforementioned media on post has been identified affected by 07/2020 Nikofix and has been skipped`);
                 }
                 else {
-                    addToDownloads(name, downloadPrefix + name + "/" + data.attributes.post_file.name, data.attributes.post_file.url);
+                    addToDownloads(name, downloadPrefix + name + "/" + baseName(data.attributes.post_file.name), data.attributes.post_file.url);
                 }
             }
 
@@ -277,7 +277,7 @@ function extractDownloadInfo(response) {
                     console.warn(`/{file_name} was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, `${downloadPrefix}${name}/${incl.attributes.file_name}`, incl.attributes.download_url);
+                addToDownloads(name, `${downloadPrefix}${name}/${baseName(incl.attributes.file_name)}`, incl.attributes.download_url);
             }
 
             // attachments
@@ -298,7 +298,7 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.url
                 });
 
-                addToDownloads(name, downloadPrefix + name + "/" + incl.attributes.name, incl.attributes.url);
+                addToDownloads(name, downloadPrefix + name + "/" + baseName(incl.attributes.name), incl.attributes.url);
             }
         });
     }

--- a/js/options.js
+++ b/js/options.js
@@ -15,6 +15,17 @@ var resetCreatorSelect = document.getElementById("resetCreatorSelect");
 var resetDownloadHistoryButton = document.getElementById("resetDownloadHistoryButton");
 var resetFeedback = document.getElementById("resetFeedback");
 var clearAllButton = document.getElementById("clearAllButton");
+var mediaTypeModeEverything = document.getElementById("mediaTypeModeEverything");
+var mediaTypeModeSelected = document.getElementById("mediaTypeModeSelected");
+var mediaTypeGroupList = document.getElementById("mediaTypeGroupList");
+var mediaTypeCheckboxes = {
+	image: document.getElementById("mediaTypeImage"),
+	video: document.getElementById("mediaTypeVideo"),
+	audio: document.getElementById("mediaTypeAudio"),
+	document: document.getElementById("mediaTypeDocument"),
+	font: document.getElementById("mediaTypeFont"),
+	archive: document.getElementById("mediaTypeArchive")
+};
 // var contentCollectionClearKnownCreatorsButton = document.getElementById("contentCollectionClearKnownCreators");
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
@@ -23,6 +34,35 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	debugCheckbox.checked = backgroundContext.debug;
 	(backgroundContext.collectionMode === "selective" ? collectionModeSelective : collectionModeGreedy).checked = true;
 	contentCollectionKnownCreators.classList.add('open');
+
+	// media type filter
+	(backgroundContext.mediaTypeMode === "selected" ? mediaTypeModeSelected : mediaTypeModeEverything).checked = true;
+	for (let group in mediaTypeCheckboxes)
+		mediaTypeCheckboxes[group].checked = backgroundContext.mediaTypes[group] !== false;
+	updateMediaTypeGroupListState();
+
+	// the group checkboxes only matter in "selected" mode; grey them out otherwise
+	function updateMediaTypeGroupListState() {
+		let enabled = mediaTypeModeSelected.checked;
+		for (let group in mediaTypeCheckboxes)
+			mediaTypeCheckboxes[group].disabled = !enabled;
+		mediaTypeGroupList.style.opacity = enabled ? "1" : "0.5";
+	}
+
+	[mediaTypeModeEverything, mediaTypeModeSelected].forEach(radio => {
+		radio.addEventListener('change', (event) => {
+			backgroundContext.mediaTypeMode = event.target.value;
+			backgroundContext.updateSettingsStorage();
+			updateMediaTypeGroupListState();
+		});
+	});
+
+	for (let group in mediaTypeCheckboxes) {
+		mediaTypeCheckboxes[group].addEventListener('change', (event) => {
+			backgroundContext.mediaTypes[group] = event.target.checked;
+			backgroundContext.updateSettingsStorage();
+		});
+	}
 
 	// open log accordion if debug is enabled
 	if (debugCheckbox.checked)
@@ -163,6 +203,8 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 		backgroundContext.downloadAttachments = true;
 		backgroundContext.useLostAndFound = true;
 		backgroundContext.collectionMode = "greedy";
+		backgroundContext.mediaTypeMode = "everything";
+		backgroundContext.mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };
 		backgroundContext.concurrentDownloads = 1;
 		backgroundContext.activeDownloads = 0;
 

--- a/js/options.js
+++ b/js/options.js
@@ -27,7 +27,14 @@ var mediaTypeCheckboxes = {
 };
 var storageModeFlat = document.getElementById("storageModeFlat");
 var storageModeByType = document.getElementById("storageModeByType");
-// var contentCollectionClearKnownCreatorsButton = document.getElementById("contentCollectionClearKnownCreators");
+
+// the group checkboxes only matter in "selected" mode; grey them out otherwise
+function updateMediaTypeGroupListState() {
+	let enabled = mediaTypeModeSelected.checked;
+	for (let group in mediaTypeCheckboxes)
+		mediaTypeCheckboxes[group].disabled = !enabled;
+	mediaTypeGroupList.style.opacity = enabled ? "1" : "0.5";
+}
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	downloadAttachmentsCheckbox.checked = backgroundContext.downloadAttachments;
@@ -40,14 +47,6 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	for (let group in mediaTypeCheckboxes)
 		mediaTypeCheckboxes[group].checked = backgroundContext.mediaTypes[group] !== false;
 	updateMediaTypeGroupListState();
-
-	// the group checkboxes only matter in "selected" mode; grey them out otherwise
-	function updateMediaTypeGroupListState() {
-		let enabled = mediaTypeModeSelected.checked;
-		for (let group in mediaTypeCheckboxes)
-			mediaTypeCheckboxes[group].disabled = !enabled;
-		mediaTypeGroupList.style.opacity = enabled ? "1" : "0.5";
-	}
 
 	[mediaTypeModeEverything, mediaTypeModeSelected].forEach(radio => {
 		radio.addEventListener('change', (event) => {

--- a/js/options.js
+++ b/js/options.js
@@ -4,7 +4,6 @@
  */
 
 var downloadAttachmentsCheckbox = document.getElementById("downloadAttachments");
-var useLostAndFoundCheckbox = document.getElementById("useLostAndFound");
 var debugCheckbox = document.getElementById("debug");
 var logCache = document.getElementById("logCache");
 var logCopyButton = document.getElementById("logCopy");
@@ -32,7 +31,6 @@ var storageModeByType = document.getElementById("storageModeByType");
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	downloadAttachmentsCheckbox.checked = backgroundContext.downloadAttachments;
-	useLostAndFoundCheckbox.checked = backgroundContext.useLostAndFound;
 	debugCheckbox.checked = backgroundContext.debug;
 	(backgroundContext.collectionMode === "selective" ? collectionModeSelective : collectionModeGreedy).checked = true;
 	contentCollectionKnownCreators.classList.add('open');
@@ -82,11 +80,6 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 
 	downloadAttachmentsCheckbox.addEventListener('change', (event) => {
 		backgroundContext.downloadAttachments = event.target.checked;
-		backgroundContext.updateSettingsStorage();
-	});
-
-	useLostAndFoundCheckbox.addEventListener('change', (event) => {
-		backgroundContext.useLostAndFound = event.target.checked;
 		backgroundContext.updateSettingsStorage();
 	});
 
@@ -213,7 +206,6 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 
 		backgroundContext.knownCreators = {};
 		backgroundContext.downloadAttachments = true;
-		backgroundContext.useLostAndFound = true;
 		backgroundContext.collectionMode = "greedy";
 		backgroundContext.mediaTypeMode = "everything";
 		backgroundContext.mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };

--- a/js/options.js
+++ b/js/options.js
@@ -26,6 +26,8 @@ var mediaTypeCheckboxes = {
 	font: document.getElementById("mediaTypeFont"),
 	archive: document.getElementById("mediaTypeArchive")
 };
+var storageModeFlat = document.getElementById("storageModeFlat");
+var storageModeByType = document.getElementById("storageModeByType");
 // var contentCollectionClearKnownCreatorsButton = document.getElementById("contentCollectionClearKnownCreators");
 
 browser.runtime.getBackgroundPage().then((backgroundContext) => {
@@ -63,6 +65,16 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 			backgroundContext.updateSettingsStorage();
 		});
 	}
+
+	// folder structure
+	(backgroundContext.storageMode === "byType" ? storageModeByType : storageModeFlat).checked = true;
+
+	[storageModeFlat, storageModeByType].forEach(radio => {
+		radio.addEventListener('change', (event) => {
+			backgroundContext.storageMode = event.target.value;
+			backgroundContext.updateSettingsStorage();
+		});
+	});
 
 	// open log accordion if debug is enabled
 	if (debugCheckbox.checked)
@@ -205,6 +217,7 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 		backgroundContext.collectionMode = "greedy";
 		backgroundContext.mediaTypeMode = "everything";
 		backgroundContext.mediaTypes = { image: true, video: true, audio: true, document: true, font: true, archive: true };
+		backgroundContext.storageMode = "flat";
 		backgroundContext.concurrentDownloads = 1;
 		backgroundContext.activeDownloads = 0;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Patreon Helper",
-	"version": "2.2",
+	"version": "2.3",
 	"description": "Downloads files in the background as you browse Patreon. Source: https://github.com/dogpixels/patreon-helper",
 	"icons": {
 		"16": "img/pax16.png",

--- a/options.html
+++ b/options.html
@@ -186,7 +186,7 @@
 		<article>
 			<label>
 				<input type="checkbox" id="useLostAndFound" name="useLostAndFound" />
-				<span><strong>Use Lost&Found Directory</strong>: Patreon Helper sometimes cannot identify a file name and whether this file has already been downloaded. In such cases, and if this option is enabled, those uncertain files will be downloaded to <code>{ArtistName}_LostAndFound</code> every time you surf Patreon.</span>
+				<span><strong>Use Lost&Found Directory</strong>: Patreon Helper sometimes cannot identify a file name and whether this file has already been downloaded. In such cases, and if this option is enabled, those uncertain files will be downloaded to the creator's <code>&lt;creator&gt;/LostAndFound</code> subfolder every time you surf Patreon.</span>
 			</label>
 		</article>
 		<article>

--- a/options.html
+++ b/options.html
@@ -115,6 +115,9 @@
 		<h1>Patreon Helper</h1>
 		<h2>News</h2>
 		<p>
+			<strong>06/2026 (2.3)</strong> New options to pick which file types to download and how to organize them into folders. Media is now identified by its Patreon ID, so content collected before this update will be downloaded once more.
+		</p>
+		<p>
 			<strong>05/2026 (2.2)</strong> More robust name identification and reset behavior.
 		</p>
 		<p>

--- a/options.html
+++ b/options.html
@@ -180,13 +180,7 @@
 		<article>
 			<label>
 				<input type="checkbox" id="downloadAttachments" name="downloadAttachments" />
-				<span><strong>Download Attachments</strong>: Some attachments can only be downloaded in a quirky way that might bother you with a "Save As" dialog for each single file (depending on your Firefox settings) and also download them multiple times to a LostAndFound directory. Enable this option if you don't mind confirming this inconvenience and want to get those additional attachments, too. Otherwise Patreon Helper will ignore them.</span>
-			</label>
-		</article>
-		<article>
-			<label>
-				<input type="checkbox" id="useLostAndFound" name="useLostAndFound" />
-				<span><strong>Use Lost&Found Directory</strong>: Patreon Helper sometimes cannot identify a file name and whether this file has already been downloaded. In such cases, and if this option is enabled, those uncertain files will be downloaded to the creator's <code>&lt;creator&gt;/LostAndFound</code> subfolder every time you surf Patreon.</span>
+				<span><strong>Download Attachments</strong>: Some attachments are hosted in a way Patreon Helper can't save into the creator folder directly. They are opened in a background tab so your browser downloads them &mdash; depending on your Firefox settings this may show a "Save As" dialog and save them to your default downloads folder instead of the <code>patreon/&lt;creator&gt;</code> structure. Enable this if you don't mind that and want those attachments too; otherwise Patreon Helper ignores them.</span>
 			</label>
 		</article>
 		<article>

--- a/options.html
+++ b/options.html
@@ -115,7 +115,7 @@
 		<h1>Patreon Helper</h1>
 		<h2>News</h2>
 		<p>
-			<strong>0/2026 (2.2)</strong> Robuster name identification and reset behavior.
+			<strong>05/2026 (2.2)</strong> More robust name identification and reset behavior.
 		</p>
 		<p>
 			<strong>05/2026 (2.1)</strong> Prevent endless retry loops.

--- a/options.html
+++ b/options.html
@@ -144,6 +144,27 @@
 			<ul id="contentCollectionKnownCreators"></ul>
 		</article>
 		<article>
+			<label style="cursor: default;">
+				<span><strong>Download File Types</strong>: Choose which kinds of files Patreon Helper downloads. This applies to all media and attachments.</span>
+			</label>
+			<label>
+				<input type="radio" name="mediaTypeMode" id="mediaTypeModeEverything" value="everything" />
+				<span><strong>Everything</strong>: Download all file types.</span>
+			</label>
+			<label>
+				<input type="radio" name="mediaTypeMode" id="mediaTypeModeSelected" value="selected" />
+				<span><strong>Only selected types</strong>: Only download the file groups you check below. Files with an unrecognized type are always downloaded.</span>
+			</label>
+			<div id="mediaTypeGroupList" style="padding: 0 8px 16px 32px;">
+				<label><input type="checkbox" id="mediaTypeImage" /> <span>Images <code>(jpg, png, gif, …)</code></span></label>
+				<label><input type="checkbox" id="mediaTypeVideo" /> <span>Videos <code>(mp4, mov, webm, …)</code></span></label>
+				<label><input type="checkbox" id="mediaTypeAudio" /> <span>Audio <code>(mp3, wav, ogg, …)</code></span></label>
+				<label><input type="checkbox" id="mediaTypeDocument" /> <span>Documents <code>(pdf, docx, txt, md, …)</code></span></label>
+				<label><input type="checkbox" id="mediaTypeFont" /> <span>Fonts <code>(ttf, otf, …)</code></span></label>
+				<label><input type="checkbox" id="mediaTypeArchive" /> <span>Archives <code>(zip, rar, 7z, …)</code></span></label>
+			</div>
+		</article>
+		<article>
 			<label>
 				<input type="checkbox" id="downloadAttachments" name="downloadAttachments" />
 				<span><strong>Download Attachments</strong>: Some attachments can only be downloaded in a quirky way that might bother you with a "Save As" dialog for each single file (depending on your Firefox settings) and also download them multiple times to a LostAndFound directory. Enable this option if you don't mind confirming this inconvenience and want to get those additional attachments, too. Otherwise Patreon Helper will ignore them.</span>

--- a/options.html
+++ b/options.html
@@ -165,6 +165,19 @@
 			</div>
 		</article>
 		<article>
+			<label style="cursor: default;">
+				<span><strong>Folder Structure</strong>: Choose how downloaded files are organized on disk.</span>
+			</label>
+			<label>
+				<input type="radio" name="storageMode" id="storageModeFlat" value="flat" />
+				<span><strong>Flat</strong>: All files go directly into the creator's folder (<code>patreon/&lt;creator&gt;/file</code>).</span>
+			</label>
+			<label>
+				<input type="radio" name="storageMode" id="storageModeByType" value="byType" />
+				<span><strong>By file type</strong>: Sort files into type subfolders (<code>patreon/&lt;creator&gt;/images</code>, <code>/videos</code>, <code>/audio</code>, <code>/documents</code>, <code>/fonts</code>, <code>/archives</code>, <code>/other</code>).</span>
+			</label>
+		</article>
+		<article>
 			<label>
 				<input type="checkbox" id="downloadAttachments" name="downloadAttachments" />
 				<span><strong>Download Attachments</strong>: Some attachments can only be downloaded in a quirky way that might bother you with a "Save As" dialog for each single file (depending on your Firefox settings) and also download them multiple times to a LostAndFound directory. Enable this option if you don't mind confirming this inconvenience and want to get those additional attachments, too. Otherwise Patreon Helper will ignore them.</span>


### PR DESCRIPTION
# Description

## Summary

Extends the Addon with user-configurable control over *which file types* get
downloaded and *how* they're organized on disk, plus a more reliable way of identifying media so
the same file isn't fetched twice. Bumps the extension to 2.3.

## New features

- **Download File Types filter** — choose which media groups to download (images,
  videos, audio, documents, fonts, archives). Unrecognized types are always kept,
  so the filter only ever removes groups you explicitly disabled.
- **Folder structure option** — keep the existing flat layout
  (`patreon/<creator>/file`) or sort files into per-type subfolders
  (`patreon/<creator>/images`, `/videos`, `/audio`, …).
- **ID-based identification** — downloads are now deduplicated by their stable
  Patreon object ID (media/attachment) instead of a parsed URL, which is more
  robust against expiring/rotating links.

## Fixes

- Strip any leading directory path from file names so they no longer create
  unwanted subfolders under the creator directory.
- Keep the real creator for media that ships without a `file_name`, naming the
  file after its media ID instead of losing the attribution. The intermediate
  `LostAndFound` subfolder has been fully removed.
- Stop attempting to download Mux-hosted (stream-only) video, which can't be saved
  as a plain file.

## Housekeeping

- Refactor: build the on-disk download path inside `addToDownloads` to shorten
  call sites.
- Tidy up file layout (grouped variable declarations, removed dead code) — no
  behavior change.
- Version bump to 2.3 with a matching News entry on the options page.

## Note for users

Because media is now identified by its Patreon ID rather than its URL, content
collected before this update will be downloaded once more on the next visit. This
is expected and one-time; it's also called out in the in-app News block.