### PR TITLE
Get media from directly-opened posts + organize by post

### DIFF
--- a/js/background-main.js
+++ b/js/background-main.js
@@ -157,5 +157,8 @@ browser.runtime.onMessage.addListener((request, sender) => {
 
 	switch (request.action) {
 		case "setPageCreator": pageCreator = request.data.creator; console.info(`pageCreator set to "${pageCreator}".`); break;
+		// single post opened directly: content script (js/content/post.js) read the JSON:API
+		// envelope out of __NEXT_DATA__; run it through the same extraction as feed responses
+		case "processPostData": extractDownloadInfo(request.data); break;
 	}
 });

--- a/js/background-main.js
+++ b/js/background-main.js
@@ -112,6 +112,23 @@ function baseName(name) {
 	return name.split(/[\\/]/).pop();
 }
 
+// turns an arbitrary string (e.g. a post title) into a single safe path segment: drops
+// characters illegal in file paths, control chars and collapses whitespace, then trims and
+// strips trailing dots/spaces (illegal on Windows) and caps the length. returns null when
+// nothing usable remains, so callers can fall back to omitting the segment.
+function sanitizePathSegment(s) {
+	if (!s) return null;
+	let seg = s
+		.replace(/[\\/:*?"<>|]/g, '')   // characters illegal in Windows file paths
+		.replace(/[\x00-\x1f]/g, '')    // control characters
+		.replace(/\s+/g, ' ')           // collapse runs of whitespace
+		.trim()
+		.replace(/[. ]+$/, '');         // Windows forbids trailing dots/spaces on a segment
+	if (seg.length > 100)
+		seg = seg.slice(0, 100).replace(/[. ]+$/, '');
+	return seg.length ? seg : null;
+}
+
 // pulls the file extension from a file name or url (ignores #fragment and ?query), lowercased
 function fileExtensionOf(s) {
 	if (!s) return null;
@@ -142,13 +159,19 @@ function isMediaTypeEnabled(filename, url) {
 	return mediaTypes[type] === true;
 }
 
-// builds the full relative download path for a file. in "byType" mode a media-type
-// subfolder is inserted between the creator folder and the file (<creator>/images/foo.png).
-// fileName is expected to already be a bare file name (see baseName).
-function buildDownloadPath(creator, fileName, url) {
+// builds the full relative download path for a file. in "byType" mode a media-type subfolder
+// is inserted between the creator folder and the file (<creator>/images/foo.png); in "byPost"
+// mode the post title is used instead (<creator>/<post title>/foo.png), falling back to the
+// bare creator folder for posts without a usable title. fileName is expected to already be a
+// bare file name (see baseName).
+function buildDownloadPath(creator, fileName, url, title) {
 	let path = downloadPrefix + creator + "/";
 	if (storageMode === "byType")
 		path += (mediaTypeFolders[getMediaType(fileName, url)] || 'other') + "/";
+	else if (storageMode === "byPost") {
+		let folder = sanitizePathSegment(title);
+		if (folder) path += folder + "/";
+	}
 	return path + fileName;
 }
 

--- a/js/content/url.js
+++ b/js/content/url.js
@@ -10,9 +10,51 @@ function detectAndSendCreator() {
 	});
 }
 
+// On a directly-opened single post, Patreon ships the post data embedded as Next.js SSR
+// state in a <script id="__NEXT_DATA__"> tag rather than via an XHR the background webRequest
+// interceptor could catch. We pull that JSON:API envelope out and hand it to the background,
+// which runs it through the very same extraction (extractDownloadInfo) as the intercepted
+// feed responses — no duplicated logic. We feature-detect the embedded post instead of
+// gating on the url path, so this keeps working even if Patreon renames the /posts/ route.
+// Only the initial server-rendered post is covered; posts reached via in-page SPA navigation
+// aren't (re)embedded here, so this runs once at load, not on SPA navigation.
+function detectAndSendPost() {
+	let el = document.getElementById("__NEXT_DATA__");
+	if (!el) return;
+
+	let nextData;
+	try {
+		nextData = JSON.parse(el.textContent);
+	} catch (e) {
+		console.error("patreon-helper: failed to parse __NEXT_DATA__", e);
+		return;
+	}
+
+	let post = nextData
+		&& nextData.props
+		&& nextData.props.pageProps
+		&& nextData.props.pageProps.bootstrapEnvelope
+		&& nextData.props.pageProps.bootstrapEnvelope.pageBootstrap
+		&& nextData.props.pageProps.bootstrapEnvelope.pageBootstrap.post;
+
+	if (!post || !post.data) return; // not a post page (or unexpected shape) — nothing to do
+
+	browser.runtime.sendMessage({ action: "processPostData", data: post });
+}
+
 detectAndSendCreator();
 
-// re-detect on SPA navigation (Patreon uses client-side routing)
+// a creator/listing page (/c/ or /cw/) is never a single post, so skip parsing __NEXT_DATA__
+// there — that parse can be sizeable. anywhere else, feature-detect the embedded post. this
+// stays safe: it only skips when we're certain it's a creator page, so if Patreon ever
+// changes its creator url scheme the regex won't match and we fall through to the check.
+if (creatorUrlRegex.exec(window.location.href) === null) {
+	detectAndSendPost();
+}
+
+// re-detect on SPA navigation (Patreon uses client-side routing). only the creator is
+// re-evaluated here; the post envelope above is server-rendered once and not refreshed on
+// client-side navigation, so re-reading it would only re-send the initial post.
 let lastUrl = window.location.href;
 new MutationObserver(() => {
 	if (window.location.href !== lastUrl) {

--- a/js/intercept.js
+++ b/js/intercept.js
@@ -11,6 +11,9 @@ var streamUrls = [
 var identifierRegex = /\/post\/\d*\/(\w*)\/|file\?(h\=\d*\&i\=\w*)/;
 var db;
 var names = {};
+// parallel to names[]: media id -> the title of the post the media belongs to, so media that
+// arrive separately in `included` can be filed under their post's folder ("byPost" mode).
+var titles = {};
 
 // extracts the creator's vanity slug from any patreon profile/checkout/join url
 function extractVanityFromUrl(url) {
@@ -126,7 +129,7 @@ function collectPosts(response) {
 // attachments_media) to the creator name, so secondary media that arrives separately in
 // `included` can be attributed to the right creator. relationship `data` is either an array
 // of references or a single reference object; both are handled.
-function mapRelationshipToCreator(relationships, key, name) {
+function mapRelationshipToCreator(relationships, key, name, title) {
     let rel = relationships[key];
     if (!rel || !rel.data) return;
 
@@ -134,9 +137,13 @@ function mapRelationshipToCreator(relationships, key, name) {
     console.log(`'${key}' found in response post relationships:`, refs);
 
     if (Array.isArray(refs)) {
-        refs.forEach(ref => { names[ref.id] = name; });
+        refs.forEach(ref => {
+            names[ref.id] = name;
+            titles[ref.id] = title;
+        });
     } else if (refs.hasOwnProperty('id')) {
         names[refs.id] = name;
+        titles[refs.id] = title;
     } else {
         console.error(`could not handle '${key}' in response post relationship; data:`, refs);
     }
@@ -152,6 +159,10 @@ function processPost(data, response) {
     // arrive separately via the 'included' array, looked up through names[])
     let name = resolveCreatorName(data, response);
     console.log(`resolved creator name: `, name);
+
+    // the post title travels alongside the creator name: filed into titles[] wherever names[]
+    // is set, so standalone media in `included` can be attributed to their post folder below.
+    let title = data.attributes && data.attributes.title;
 
     if (
         data.attributes.hasOwnProperty('post_file') &&
@@ -177,7 +188,7 @@ function processPost(data, response) {
             console.warn(`the aforementioned media on post has been identified affected by 07/2020 Nikofix and has been skipped`);
         }
         else {
-            addToDownloads(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url, objectIdentifier("media", data.attributes.post_file.media_id));
+            addToDownloads(name, baseName(data.attributes.post_file.name), data.attributes.post_file.url, objectIdentifier("media", data.attributes.post_file.media_id), title);
         }
     }
 
@@ -187,7 +198,7 @@ function processPost(data, response) {
         findMediaUrls(data.attributes.content).forEach(url => {
             console.info(`url found in post content, url:`, url);
             let file = url.split('/').pop().split('#')[0].split('?')[0];
-            addToDownloads(name, file, url);
+            addToDownloads(name, file, url, undefined, title);
         });
     }
 
@@ -201,6 +212,7 @@ function processPost(data, response) {
         console.log(`'post_metadata' found in response; image_order:`, data.attributes.post_metadata.image_order);
         data.attributes.post_metadata.image_order.forEach(id => {
             names[id] = name;
+            titles[id] = title;
         });
     }
 
@@ -209,7 +221,7 @@ function processPost(data, response) {
     // without it they would fall back to unknownCreator in the 'included' media branch below.
     if (data.hasOwnProperty('relationships') && data.relationships) {
         ['images', 'audio', 'attachments', 'attachments_media'].forEach(key => {
-            mapRelationshipToCreator(data.relationships, key, name);
+            mapRelationshipToCreator(data.relationships, key, name, title);
         });
     }
 }
@@ -263,7 +275,7 @@ function extractDownloadInfo(response) {
                     console.warn(`file_name was null, replaced it by '${incl.attributes.file_name}'`);
                 }
 
-                addToDownloads(name, baseName(incl.attributes.file_name), incl.attributes.download_url, objectIdentifier("media", incl.id));
+                addToDownloads(name, baseName(incl.attributes.file_name), incl.attributes.download_url, objectIdentifier("media", incl.id), titles[incl.id]);
             }
 
             // attachments
@@ -284,7 +296,7 @@ function extractDownloadInfo(response) {
                     url: incl.attributes.url
                 });
 
-                addToDownloads(name, baseName(incl.attributes.name), incl.attributes.url, objectIdentifier("attachment", incl.id));
+                addToDownloads(name, baseName(incl.attributes.name), incl.attributes.url, objectIdentifier("attachment", incl.id), titles[incl.id]);
             }
         });
     }
@@ -312,12 +324,13 @@ function findMediaUrls(text) {
     return ret;
 }
 
-async function addToDownloads(creator, fileName, url, identifier) {
+async function addToDownloads(creator, fileName, url, identifier, title) {
     registerCreator(creator);
 
     // build the on-disk path here so callers only pass the bare file name (and don't
-    // have to repeat creator/url for buildDownloadPath on top of passing them to us)
-    let filename = buildDownloadPath(creator, fileName, url);
+    // have to repeat creator/url for buildDownloadPath on top of passing them to us).
+    // title is only consumed in "byPost" storage mode; ignored otherwise.
+    let filename = buildDownloadPath(creator, fileName, url, title);
 
     console.info(`Queueing: creator: "${creator}", filename: "${filename}", url: "${url}"`);
 

--- a/js/options.js
+++ b/js/options.js
@@ -27,6 +27,7 @@ var mediaTypeCheckboxes = {
 };
 var storageModeFlat = document.getElementById("storageModeFlat");
 var storageModeByType = document.getElementById("storageModeByType");
+var storageModeByPost = document.getElementById("storageModeByPost");
 
 // the group checkboxes only matter in "selected" mode; grey them out otherwise
 function updateMediaTypeGroupListState() {
@@ -64,9 +65,10 @@ browser.runtime.getBackgroundPage().then((backgroundContext) => {
 	}
 
 	// folder structure
-	(backgroundContext.storageMode === "byType" ? storageModeByType : storageModeFlat).checked = true;
+	let storageModeRadios = { flat: storageModeFlat, byType: storageModeByType, byPost: storageModeByPost };
+	(storageModeRadios[backgroundContext.storageMode] || storageModeFlat).checked = true;
 
-	[storageModeFlat, storageModeByType].forEach(radio => {
+	[storageModeFlat, storageModeByType, storageModeByPost].forEach(radio => {
 		radio.addEventListener('change', (event) => {
 			backgroundContext.storageMode = event.target.value;
 			backgroundContext.updateSettingsStorage();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Patreon Helper",
-	"version": "2.4",
+	"version": "2.5",
 	"description": "Downloads files in the background as you browse Patreon. Source: https://github.com/dogpixels/patreon-helper",
 	"icons": {
 		"16": "img/pax16.png",

--- a/options.html
+++ b/options.html
@@ -115,6 +115,9 @@
 		<h1>Patreon Helper</h1>
 		<h2>News</h2>
 		<p>
+			<strong>06/2026 (2.5)</strong> Media is now also grabbed from directly-opened single posts, and downloads can be organized into per-post folders.
+		</p>
+		<p>
 			<strong>06/2026 (2.4)</strong> Content from the home feed is collected again properly, plus a fix for media links in post text.
 		</p>
 		<p>

--- a/options.html
+++ b/options.html
@@ -182,6 +182,10 @@
 				<input type="radio" name="storageMode" id="storageModeByType" value="byType" />
 				<span><strong>By file type</strong>: Sort files into type subfolders (<code>patreon/&lt;creator&gt;/images</code>, <code>/videos</code>, <code>/audio</code>, <code>/documents</code>, <code>/fonts</code>, <code>/archives</code>, <code>/other</code>).</span>
 			</label>
+			<label>
+				<input type="radio" name="storageMode" id="storageModeByPost" value="byPost" />
+				<span><strong>By post</strong>: Group files by the post they came from (<code>patreon/&lt;creator&gt;/&lt;post title&gt;/file</code>). Posts without a title go directly into the creator's folder.</span>
+			</label>
 		</article>
 		<article>
 			<label>


### PR DESCRIPTION
## Fixed issues
- Fixes #14 — note that the "By post" structure groups downloads by the post
  **title**, not the post id, so the folders stay human-readable.

## Summary
Adds two things and bumps the version to 2.5:
1. Grabs downloadable media from a **directly-opened single post**, which ships
   its data embedded in the page instead of via an interceptable API call.
2. A new **"By post" folder structure** option that files downloads under the
   post they came from (`patreon/<creator>/<post title>/file`).

## Problem
- **Single posts**: opening a post directly (`patreon.com/posts/...`) makes no
  XHR the background `webRequest` interceptor could catch. The page is Next.js
  SSR and embeds the post (JSON:API `data` + `included`) in a
  `<script id="__NEXT_DATA__">` tag, so its media was never collected.
- **Folder structure**: downloads could only be organized flat or by file type.
  There was no way to keep each post's media together, and the post title was
  never carried through the extraction (media that arrive separately in
  `included` are only mapped to the creator, not to their post).

## Changes
- **Single-post extraction** (`js/content/url.js`): the existing content script
  now also feature-detects the embedded post envelope in `__NEXT_DATA__`
  (`pageBootstrap.post`) and forwards it to the background via a
  `processPostData` message. The background runs it through the very same
  `extractDownloadInfo` pipeline as intercepted feed responses — no duplicated
  logic. Detection is by feature, not by url path, so it survives a `/posts/`
  route rename; it is skipped on creator pages to avoid an unnecessary parse.
- **By-post folders** (`js/intercept.js`, `js/background-main.js`): a parallel
  `titles[]` map (media id → post title) is populated wherever `names[]` is, so
  media arriving separately in `included` are filed under the right post. The
  title is threaded through `addToDownloads` into `buildDownloadPath`, which
  gains a `byPost` mode. Titles are sanitized into one safe path segment
  (illegal/control chars stripped, whitespace collapsed, trailing dots/spaces
  removed, length-capped); untitled posts fall back to the bare creator folder.
- **Options** (`options.html`, `js/options.js`): a third "By post" radio under
  Folder Structure, wired into the existing storage-mode handling.